### PR TITLE
Fix complex abs

### DIFF
--- a/src/complex_double/z_unifact_mergebulge.f90
+++ b/src/complex_double/z_unifact_mergebulge.f90
@@ -224,6 +224,14 @@ subroutine z_unifact_mergebulge(JOB,N,STR,STP,Q,D,B,INFO)
     ! compute phase
     call d_rot2_vec2gen(s3r,s3i,phr,phi,nrm)
      
+    ! check INFO in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+      if (INFO.NE.0) then 
+        return 
+      end if 
+    end if
+
     ! update Q
     c2r = c3r*phr + c3i*phi
     c2i = -c3r*phi + c3i*phr

--- a/src/complex_double/z_unifact_mergebulge.f90
+++ b/src/complex_double/z_unifact_mergebulge.f90
@@ -152,14 +152,7 @@ subroutine z_unifact_mergebulge(JOB,N,STR,STP,Q,D,B,INFO)
     s3i = s1*c2i - s2*c1i
     
     ! compute phase
-    nrm = abs(cmplx(s3r,s3i,kind=8))
-    if(nrm /= 0)then
-      phr = s3r/nrm
-      phi = s3i/nrm
-    else
-      phr = 1d0
-      phi = 0d0
-    end if
+    call d_rot2_vec2gen(s3r,s3i,phr,phi,nrm)
      
     ! update Q
     c2r = c3r*phr + c3i*phi
@@ -220,14 +213,7 @@ subroutine z_unifact_mergebulge(JOB,N,STR,STP,Q,D,B,INFO)
     s3i = -(s1*c2i - s2*c1i)
      
     ! compute phase
-    nrm = abs(cmplx(s3r,s3i,kind=8))
-    if(nrm /= 0)then
-       phr = s3r/nrm
-       phi = s3i/nrm
-    else
-       phr = 1d0
-       phi = 0d0
-    end if
+    call d_rot2_vec2gen(s3r,s3i,phr,phi,nrm)
      
     ! update Q
     c2r = c3r*phr + c3i*phi

--- a/src/complex_double/z_unifact_mergebulge.f90
+++ b/src/complex_double/z_unifact_mergebulge.f90
@@ -152,7 +152,16 @@ subroutine z_unifact_mergebulge(JOB,N,STR,STP,Q,D,B,INFO)
     s3i = s1*c2i - s2*c1i
     
     ! compute phase
-    call d_rot2_vec2gen(s3r,s3i,phr,phi,nrm)
+    call d_rot2_vec2gen(s3r,s3i,phr,phi,nrm,INFO)
+
+    ! check INFO in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+      if (INFO.NE.0) then 
+        return 
+      end if 
+    end if
+
      
     ! update Q
     c2r = c3r*phr + c3i*phi

--- a/src/complex_double/z_unifact_singlestep.f90
+++ b/src/complex_double/z_unifact_singlestep.f90
@@ -169,7 +169,16 @@ subroutine z_unifact_singlestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   ! project shift onto unit circle
   ar = dble(shift)
   ai = aimag(shift)
-  call d_rot2_vec2gen(ar,ai,br,bi,nrm)
+  call d_rot2_vec2gen(ar,ai,br,bi,nrm,INFO)
+
+  ! check INFO in debug mode
+  if (DEBUG) then
+     call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+     if (INFO.NE.0) then 
+        return 
+     end if
+  end if
+  
   shift = cmplx(br,bi,kind=8)
 
 

--- a/src/complex_double/z_unifact_singlestep.f90
+++ b/src/complex_double/z_unifact_singlestep.f90
@@ -169,7 +169,7 @@ subroutine z_unifact_singlestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   ! project shift onto unit circle
   ar = dble(shift)
   ai = aimag(shift)
-  d_rot2_vec2gen(ar,ai,br,bi,nrm)
+  call d_rot2_vec2gen(ar,ai,br,bi,nrm)
   shift = cmplx(br,bi,kind=8)
 
 

--- a/src/complex_double/z_unifact_singlestep.f90
+++ b/src/complex_double/z_unifact_singlestep.f90
@@ -68,7 +68,7 @@ subroutine z_unifact_singlestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   
   ! compute variables
   integer :: ii, ind1, ind2
-  real(8) :: s1, s2
+  real(8) :: s1, s2, ar, ai, br, bi, nrm
   real(8) :: bulge(3),binv(3)
   complex(8) :: shift
   complex(8) :: block(2,2), temp(2,2), eigs(2)
@@ -157,6 +157,7 @@ subroutine z_unifact_singlestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
     end if
           
     ! choose wikinson shift
+    ! complex abs does not matter here
     if(abs(block(2,2)-eigs(1)) < abs(block(2,2)-eigs(2)))then
       shift = eigs(1)
     else
@@ -166,10 +167,11 @@ subroutine z_unifact_singlestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   end if
         
   ! project shift onto unit circle
-  if (abs(shift) .EQ. 0d0) then
-    shift = cmplx(1d0,0d0,kind=8)
-  end if
-  shift = shift/abs(shift)
+  ar = dble(shift)
+  ai = aimag(shift)
+  d_rot2_vec2gen(ar,ai,br,bi,nrm)
+  shift = cmplx(br,bi,kind=8)
+
 
   ! build bulge
   call z_unifact_buildbulge(N,STR,Q,D,shift,bulge,INFO)

--- a/src/complex_double/z_unihess_factor.f90
+++ b/src/complex_double/z_unihess_factor.f90
@@ -110,12 +110,28 @@ subroutine z_unihess_factor(N,H,Q,D,INFO)
     Q(3*(ii-1)+3) = s
           
     ! store in D
-    call d_rot2_vec2gen(dble(H(ii,ii)),aimag(H(ii,ii)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm)
+    call d_rot2_vec2gen(dble(H(ii,ii)),aimag(H(ii,ii)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm,INFO)
    
+    ! check INFO in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+      if (INFO.NE.0) then 
+        return 
+      end if 
+    end if
+
   end do
   
   ! store in D
-  call d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(N-1)+1),D(2*(N-1)+2),nrm)
+  call d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(N-1)+1),D(2*(N-1)+2),nrm,INFO)
+  
+  ! check INFO in debug mode
+  if (DEBUG) then
+     call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+     if (INFO.NE.0) then 
+        return 
+     end if
+  end if
   
   ! check for unitarity       
   if (abs(nrm-1d0) >= tol) then

--- a/src/complex_double/z_unihess_factor.f90
+++ b/src/complex_double/z_unihess_factor.f90
@@ -110,12 +110,12 @@ subroutine z_unihess_factor(N,H,Q,D,INFO)
     Q(3*(ii-1)+3) = s
           
     ! store in D
-    d_rot2_vec2gen(dble(H(ii,ii)),aimag(H(ii,ii)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm)
+    call d_rot2_vec2gen(dble(H(ii,ii)),aimag(H(ii,ii)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm)
    
   end do
   
   ! store in D
-  d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(N-1)+1),D(2*(N-1)+2),nrm)
+  call d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(N-1)+1),D(2*(N-1)+2),nrm)
   
   ! check for unitarity       
   if (abs(nrm-1d0) >= tol) then

--- a/src/complex_double/z_unihess_factor.f90
+++ b/src/complex_double/z_unihess_factor.f90
@@ -110,13 +110,15 @@ subroutine z_unihess_factor(N,H,Q,D,INFO)
     Q(3*(ii-1)+3) = s
           
     ! store in D
-    D(2*(ii-1)+1) = dble(H(ii,ii))/abs(H(ii,ii))
-    D(2*(ii-1)+2) = aimag(H(ii,ii))/abs(H(ii,ii))
+    d_rot2_vec2gen(dble(H(ii,ii)),aimag(H(ii,ii)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm)
    
   end do
   
+  ! store in D
+  d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm)
+  
   ! check for unitarity       
-  if (abs(abs(H(N,N))-1d0) >= tol) then
+  if (abs(nrm-1d0) >= tol) then
     INFO = -2
     ! print error in debug mode
     if (DEBUG) then
@@ -125,8 +127,4 @@ subroutine z_unihess_factor(N,H,Q,D,INFO)
     return          
   end if
           
-  ! store in D
-  D(2*(N-1)+1) = dble(H(N,N))/abs(H(N,N))
-  D(2*(N-1)+2) = aimag(H(N,N))/abs(H(N,N))
-
 end subroutine z_unihess_factor

--- a/src/complex_double/z_unihess_factor.f90
+++ b/src/complex_double/z_unihess_factor.f90
@@ -115,7 +115,7 @@ subroutine z_unihess_factor(N,H,Q,D,INFO)
   end do
   
   ! store in D
-  d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(ii-1)+1),D(2*(ii-1)+2),nrm)
+  d_rot2_vec2gen(dble(H(N,N)),aimag(H(N,N)),D(2*(N-1)+1),D(2*(N-1)+2),nrm)
   
   ! check for unitarity       
   if (abs(nrm-1d0) >= tol) then

--- a/src/double/d_2x2array_eig.f90
+++ b/src/double/d_2x2array_eig.f90
@@ -40,9 +40,9 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   
   ! compute variables
   integer :: ii, id
-  real(8) :: temp, nrm1, nrm2
+  real(8) :: detm, temp, nrm1, nrm2
   complex(8) :: WORK(4)
-  complex(8) :: trace, detm, disc
+  complex(8) :: trace, disc
   
   ! initialize info
   INFO = 0
@@ -61,7 +61,7 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
 
   ! compute intermediate values
   trace = cmplx(H(1,1) + H(2,2),0d0,kind=8)
-  detm = cmplx(H(1,1)*H(2,2) - H(2,1)*H(1,2),0d0,kind=8)
+  detm = H(1,1)*H(2,2) - H(2,1)*H(1,2)
   temp = (H(1,1)-H(2,2))**2 + 4d0*H(1,2)*H(2,1)
   
   ! zero roots
@@ -82,10 +82,10 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
     ! compute E
     if(abs(trace+disc) > abs(trace-disc))then
       E(1) = (trace+disc)/2d0
-      E(2) = detm/E(1)
+      E(2) = cmplx(detm,0d0,kind=8)/E(1)
     else
       E(1) = (trace-disc)/2d0
-      E(2) = detm/E(1)
+      E(2) = cmplx(detm,0d0,kind=8)/E(1)
     end if
     
   end if
@@ -131,8 +131,10 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   end if
 
   ! normalize first column of Z
-  nrm1 = abs(Z(1,1))
+  nrm1 = abs(Z(1,1)) 
   nrm2 = abs(Z(2,1))
+  ! complex abs does not matter here, since nrm2 < eps_single 
+  ! => nrm2**2 < eps_double
   if (nrm1 > nrm2) then
     nrm2 = nrm2/nrm1
     temp = nrm1*sqrt(1d0 + nrm2*nrm2)

--- a/src/double/d_2x2array_eig.f90
+++ b/src/double/d_2x2array_eig.f90
@@ -40,9 +40,8 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   
   ! compute variables
   integer :: ii, id
-  real(8) :: detm, temp, nrm1, nrm2
-  complex(8) :: WORK(4)
-  complex(8) :: trace, disc
+  real(8) :: trace, disc, detm, temp, nrm1, nrm2
+  complex(8) :: WORK(4), swap
   
   ! initialize info
   INFO = 0
@@ -60,7 +59,7 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   end if  
 
   ! compute intermediate values
-  trace = cmplx(H(1,1) + H(2,2),0d0,kind=8)
+  trace = H(1,1) + H(2,2)
   detm = H(1,1)*H(2,2) - H(2,1)*H(1,2)
   temp = (H(1,1)-H(2,2))**2 + 4d0*H(1,2)*H(2,1)
   
@@ -71,20 +70,20 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   
   ! imaginary roots
   else if (temp < 0) then
-    disc = cmplx(0d0,sqrt(-temp),kind=8)
-    E(1) = (trace+disc)/2d0
-    E(2) = (trace-disc)/2d0
-    
+    disc = sqrt(-temp)
+    E(1) = cmplx(trace,disc,kind=8)/2d0
+    E(2) = cmplx(trace,-disc,kind=8)/2d0    
+
   ! real roots
   else
-    disc = cmplx(sqrt(temp),0d0,kind=8)
+    disc = sqrt(temp)
     
     ! compute E
     if(abs(trace+disc) > abs(trace-disc))then
-      E(1) = (trace+disc)/2d0
+      E(1) = cmplx((trace+disc)/2d0,0d0,kind=8)
       E(2) = cmplx(detm,0d0,kind=8)/E(1)
     else
-      E(1) = (trace-disc)/2d0
+      E(1) = cmplx((trace-disc)/2d0,0d0,kind=8)
       E(2) = cmplx(detm,0d0,kind=8)/E(1)
     end if
     
@@ -97,6 +96,7 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   WORK(4) = H(2,2) - E(2)
   
   id = 1
+  ! complex abs does not matter here
   temp = abs(WORK(1))
   do ii=1,3
     if(abs(WORK(ii+1)) > temp) then
@@ -119,15 +119,15 @@ subroutine d_2x2array_eig(H,E,Z,INFO)
   else if (id .EQ. 3) then
     Z(1,1) = H(1,2)
     Z(2,1) = -WORK(3)
-    trace = E(1)
+    swap = E(1)
     E(1) = E(2)
-    E(2) = trace
+    E(2) = swap
   else
     Z(1,1) = -WORK(4)
     Z(2,1) = H(2,1)
-    trace = E(1)
+    swap = E(1)
     E(1) = E(2)
-    E(2) = trace
+    E(2) = swap
   end if
 
   ! normalize first column of Z

--- a/src/double/d_orthfact_doublestep.f90
+++ b/src/double/d_orthfact_doublestep.f90
@@ -66,10 +66,10 @@ subroutine d_orthfact_doublestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   ! compute variables
   integer :: ii, ind
   real(8) :: s1, s2
-  real(8) :: b1(2), b2(2), b3(2), temp(2)
+  real(8) :: b1(2), b2(2), b3(2), temp(2), nrm
   real(8) :: block(2,2) 
   complex(8) :: eigs(2), h(2,2)
-  
+
   ! initialize INFO
   INFO = 0
  
@@ -419,14 +419,8 @@ subroutine d_orthfact_doublestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   else
   
     ! normalize shifts
-    if (abs(eigs(1)).EQ.0d0) then
-      eigs(1) = cmplx(0d0,1d0,kind=8)
-    end if
-    eigs(1) = eigs(1)/abs(eigs(1)) 
-
+    call d_rot2_vec2gen(dble(eigs(1)),aimag(eigs(1)),temp(1),temp(2),nrm) 
     ! build bulge
-    temp(1) = dble(eigs(1))
-    temp(2) = aimag(eigs(1))
     call d_orthfact_buildbulge('D',N,STR,Q,D,temp,b1,b2,INFO)
           
     ! check INFO in debug mode

--- a/src/double/d_orthfact_doublestep.f90
+++ b/src/double/d_orthfact_doublestep.f90
@@ -419,7 +419,16 @@ subroutine d_orthfact_doublestep(COMPZ,N,STR,STP,Q,D,Z,ITCNT,INFO)
   else
   
     ! normalize shifts
-    call d_rot2_vec2gen(dble(eigs(1)),aimag(eigs(1)),temp(1),temp(2),nrm) 
+    call d_rot2_vec2gen(dble(eigs(1)),aimag(eigs(1)),temp(1),temp(2),nrm,INFO) 
+
+    ! check INFO in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+      if (INFO.NE.0) then 
+        return 
+      end if 
+    end if
+
     ! build bulge
     call d_orthfact_buildbulge('D',N,STR,Q,D,temp,b1,b2,INFO)
           


### PR DESCRIPTION
Fix #27 : In many functions the complex abs could be avoided for one of the following two reasons:
+ the abs was used for normalization => replacement with d_rot2_vec2gen
+ the complex variable was set to cmplx(real,0d0) => replace complex variable with real variable

In other places (eig, geneig) the use of complex abs was not harmful, since the result was later squared. Hence, an single precision underflow in the complex abs computation would have been equivalent to a double precision underflow for the square.