### PR TITLE
Feature twisted upr1

### DIFF
--- a/src/complex_double/z_rot3_vec3gen.f90
+++ b/src/complex_double/z_rot3_vec3gen.f90
@@ -8,8 +8,7 @@
 ! This routine computes the generator for a Givens rotation represented
 ! by 3 real numbers: the real and imaginary parts of a complex cosine
 ! and a scrictly real sine. The first column is constructed to be 
-! parallel with the complex vector [A,B]^T. The (3->3) refers to the 
-! 3 double inputs and 3 double outputs (excluding the norm).
+! parallel with the complex vector [A,B]^T.
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !

--- a/src/complex_double/z_upr1fact_mergebulge.f90
+++ b/src/complex_double/z_upr1fact_mergebulge.f90
@@ -31,6 +31,9 @@
 !  K               INTEGER
 !                    index where fusion should happen
 !
+!  P               LOGICAL array of dimension (N-2)
+!                    array of position flags for Q
+!
 !  Q               REAL(8) array of dimension (3*(N-1))
 !                    array of generators for givens rotations
 !

--- a/src/complex_double/z_upr1fact_mergebulge.f90
+++ b/src/complex_double/z_upr1fact_mergebulge.f90
@@ -7,8 +7,7 @@
 !
 ! This routine fuses a Givens rotation represented by 3 real numbers: 
 ! the real and imaginary parts of a complex cosine and a scrictly real 
-! sine into the top or bottom of a unitary hessenberg matrix that is 
-! stored as a product of givens rotations and a complex diagonal matrix. 
+! sine into the extended hessenberg part of a upr1 pencil.
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !

--- a/src/complex_double/z_upr1fact_mergebulge.f90
+++ b/src/complex_double/z_upr1fact_mergebulge.f90
@@ -1,0 +1,192 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! z_upr1fact_mergebulge 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine fuses a Givens rotation represented by 3 real numbers: 
+! the real and imaginary parts of a complex cosine and a scrictly real 
+! sine into the top or bottom of a unitary hessenberg matrix that is 
+! stored as a product of givens rotations and a complex diagonal matrix. 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  JOB             CHARACTER
+!                    'L': fuse from the left
+!                    'R': fuse from the right
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  STR             INTEGER
+!                    index of the top most givens rotation where 
+!                    fusion could happen
+!
+!  STP             INTEGER
+!                    index of the bottom most givens rotation where 
+!                    fusion could happen
+!
+!  K               INTEGER
+!                    index where fusion should happen
+!
+!  Q               REAL(8) array of dimension (3*(N-1))
+!                    array of generators for givens rotations
+!
+!  D               REAL(8) array of dimension (2*N+1)
+!                    array of generators for complex diagonal matrix
+!
+!  B               REAL(8) array of dimension (3)
+!                    generators for rotation that will be fused
+!
+! OUTPUT VARIABLES:
+!
+!  INFO           INTEGER
+!                   INFO = 1 implies a core transformation interferes
+!                   INFO = 0 implies successful computation
+!                   INFO = -1 implies JOB is invalid
+!                   INFO = -2 implies N is invalid
+!                   INFO = -3 implies STR is invalid
+!                   INFO = -4 implies STP is invalid
+!                   INFO = -7 implies B is invalid
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine z_upr1fact_mergebulge(JOB,N,STR,STP,K,P,Q,D,G,INFO)
+
+  implicit none
+  
+  ! input variables
+  character, intent(in) :: JOB
+  integer, intent(in) :: N, STR, STP, K
+  logical, intent(in) :: P(N-2)
+  real(8), intent(inout) :: Q(3*(N-1)),D(2*(N+1))
+  real(8), intent(in) :: G(3)
+  integer, intent(inout) :: INFO
+  
+  ! compute variables
+  integer :: ii
+  
+  ! initialize INFO
+  INFO = 0
+
+  ! check input in debug mode
+  if (DEBUG) then
+  
+    ! check JOB
+    if ((JOB.NE.'L').AND.(JOB.NE.'R')) then
+      INFO = -1
+      call u_infocode_check(__FILE__,__LINE__,"JOB must be 'L' or 'R'",INFO,INFO)
+      return
+    end if
+    
+    ! check N
+    if (N < 2) then
+      INFO = -2
+      call u_infocode_check(__FILE__,__LINE__,"N must be at least 2",INFO,INFO)
+      return
+    end if
+    
+    ! check STR
+    if ((STR < 1).OR.(STR > N-1)) then
+      INFO = -3
+      call u_infocode_check(__FILE__,__LINE__,"STR must 1 <= STR <= N-1",INFO,INFO)
+      return
+    end if 
+    
+    ! check STP
+    if ((STP < STR).OR.(STP > N-1)) then
+      INFO = -4
+      call u_infocode_check(__FILE__,__LINE__,"STP must STR <= STP <= N-1",INFO,INFO)
+      return
+    end if 
+    
+    ! check K
+    if ((K < STR).OR.(STP < K)) then
+      INFO = -5
+      call u_infocode_check(__FILE__,__LINE__,"STP must STR <= K <= STP",INFO,INFO)
+      return
+    end if   
+    
+    ! check Q
+    call d_1Darray_check(3*(N-1),Q,INFO)
+    if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-7)
+      return
+    end if 
+    
+    ! check D
+    call d_1Darray_check(2*(N+1),D,INFO)
+    if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,-8)
+      return
+    end if 
+    
+    ! check G
+    call d_1Darray_check(3,G,INFO)
+    if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"G is invalid",INFO,-9)
+      return
+    end if  
+    
+    ! check for valid fusion
+    ! JOB == L
+    if (JOB.EQ.'L') then
+      
+      ! check upper core transformation
+      if (K > 1) then
+        if (P(K-1).EQV..FALSE.) then
+          INFO = 1 
+          call u_infocode_check(__FILE__,__LINE__,"Upper core transformation interferes",INFO,INFO)
+          return
+        end if
+      end if
+      
+      ! check lower core transformation
+      if (K < (N-1)) then
+        if (P(K).EQV..TRUE.) then
+          INFO = 1 
+          call u_infocode_check(__FILE__,__LINE__,"Lower core transformation interferes",INFO,INFO)
+          return
+        end if
+      end if
+      
+     ! JOB == R
+     else
+     
+      ! check upper core transformation
+      if (K > 1) then
+        if (P(K-1).EQV..TRUE.) then
+          INFO = 1 
+          call u_infocode_check(__FILE__,__LINE__,"Upper core transformation interferes",INFO,INFO)
+          return
+        end if
+      end if
+      
+      ! check lower core transformation
+      if (K < (N-1)) then
+        if (P(K).EQV..FALSE.) then
+          INFO = 1 
+          call u_infocode_check(__FILE__,__LINE__,"Lower core transformation interferes",INFO,INFO)
+          return
+        end if
+      end if
+     
+     end if     
+
+  end if
+  
+  ! fusion from left
+  if(JOB.EQ.'L')then
+  
+
+     
+  ! fusion from right
+  else
+  
+
+     
+  end if
+
+end subroutine z_upr1fact_mergebulge

--- a/src/complex_double/z_upr1fact_mergebulge.f90
+++ b/src/complex_double/z_upr1fact_mergebulge.f90
@@ -7,7 +7,7 @@
 !
 ! This routine fuses a Givens rotation represented by 3 real numbers: 
 ! the real and imaginary parts of a complex cosine and a scrictly real 
-! sine into the extended hessenberg part of a upr1 pencil.
+! sine into the unitary extended hessenberg part of a upr1 pencil.
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
@@ -37,7 +37,7 @@
 !  D               REAL(8) array of dimension (2*N+1)
 !                    array of generators for complex diagonal matrix
 !
-!  B               REAL(8) array of dimension (3)
+!  G               REAL(8) array of dimension (3)
 !                    generators for rotation that will be fused
 !
 ! OUTPUT VARIABLES:
@@ -49,7 +49,7 @@
 !                   INFO = -2 implies N is invalid
 !                   INFO = -3 implies STR is invalid
 !                   INFO = -4 implies STP is invalid
-!                   INFO = -7 implies B is invalid
+!                   INFO = -7 implies G is invalid
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine z_upr1fact_mergebulge(JOB,N,STR,STP,K,P,Q,D,G,INFO)

--- a/src/complex_double/z_upr1fact_twistedqz.f90
+++ b/src/complex_double/z_upr1fact_twistedqz.f90
@@ -190,7 +190,7 @@ subroutine z_upr1fact_twistedqz(ALG,COMPZ,N,P,FUN,Q,D,R,V,W,ITS,INFO)
     end if
     
     ! check for deflation
-    call z_upr1fact_deflationcheck(N,start_index,stop_index,zero_index,P,Q,D,it_count,ITS,INFO)
+    call z_upr1fact_deflationcheck(N,start_index,stop_index,zero_index,P,Q,D(1,:),it_count,ITS,INFO)
     
     ! check INFO in debug mode
     if (DEBUG) then

--- a/test/complex_double/test_z_upr1fact_buildbulge.f90
+++ b/test/complex_double/test_z_upr1fact_buildbulge.f90
@@ -150,6 +150,5 @@ program test_z_upr1fact_buildbulge
   
   ! print success
   call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
-  
      
 end program test_z_upr1fact_buildbulge

--- a/test/complex_double/test_z_upr1fact_deflationcheck.f90
+++ b/test/complex_double/test_z_upr1fact_deflationcheck.f90
@@ -22,7 +22,7 @@ program test_z_upr1fact_deflationcheck
   integer, parameter :: N = 6
   integer :: ii, ind, INFO, ITCNT, STR, STP, ZERO, ITS(N-1)
   logical :: P(N-2)
-  real(8) :: Q(3*(N-1)), D(2,2*(N+1))
+  real(8) :: Q(3*(N-1)), D(2*(N+1))
   complex(8) :: H1(N+1,N+1), H2(N+1,N+1)
   
   ! tolerance
@@ -62,7 +62,7 @@ program test_z_upr1fact_deflationcheck
     ! initialize D
     D = 0d0
     do ii=1,(N+1)
-      D(1,2*ii-1) = 1d0
+      D(2*ii-1) = 1d0
     end do
         
     ! initialize H1
@@ -130,7 +130,7 @@ program test_z_upr1fact_deflationcheck
     ! initialize D
     D = 0d0
     do ii=1,(N+1)
-      D(1,2*ii-1) = 1d0
+      D(2*ii-1) = 1d0
     end do
         
     ! initialize H1
@@ -204,7 +204,7 @@ program test_z_upr1fact_deflationcheck
     ! initialize D
     D = 0d0
     do ii=1,(N+1)
-      D(1,2*ii-1) = 1d0
+      D(2*ii-1) = 1d0
     end do
         
     ! initialize H1
@@ -277,7 +277,7 @@ program test_z_upr1fact_deflationcheck
     ! initialize D
     D = 0d0
     do ii=1,(N+1)
-      D(1,2*ii-1) = 1d0
+      D(2*ii-1) = 1d0
     end do
         
     ! initialize H1
@@ -349,7 +349,7 @@ subroutine z_upr1fact_form_hess_matrix(N,P,Q,D,H)
   ! input variables
   integer, intent(in) :: N
   logical, intent(in) :: P(N-2)
-  real(8), intent(in) :: Q(3*(N-1)), D(2,2*(N+1))
+  real(8), intent(in) :: Q(3*(N-1)), D(2*(N+1))
   complex(8), intent(inout) :: H(N+1,N+1)
   
   ! compute variables
@@ -383,7 +383,7 @@ subroutine z_upr1fact_form_hess_matrix(N,P,Q,D,H)
   
   ! apply D
   do ii=1,(N+1)
-    H(:,ii) = H(:,ii)*cmplx(D(1,2*ii-1),D(1,2*ii),kind=8)
+    H(:,ii) = H(:,ii)*cmplx(D(2*ii-1),D(2*ii),kind=8)
   end do
   
 end subroutine z_upr1fact_form_hess_matrix

--- a/test/complex_double/test_z_upr1fact_mergebulge.f90
+++ b/test/complex_double/test_z_upr1fact_mergebulge.f90
@@ -9,7 +9,7 @@
 ! The following tests are run:
 !
 ! 1) Q = [0, -1; 1, 0], P = FALSE, D = I, K = 1, JOB = L and 
-!    G = [0, 1; -1, 0]
+!    G = [1+1i,1]/sqrt(3)
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 program test_z_upr1fact_mergebulge
@@ -18,9 +18,11 @@ program test_z_upr1fact_mergebulge
   
   ! compute variables
   integer, parameter :: N = 3
+  real(8), parameter :: tol = 1d1*epsilon(1d0)
   integer :: ii
   logical :: P(N-2)
   real(8) :: Q(3*(N-1)),D(2*(N+1)), G(3)
+  complex(8) :: temp(2,2), H1(N+1,N+1), H2(N+1,N+1)
   integer :: INFO
   
   ! timing variables
@@ -50,11 +52,22 @@ program test_z_upr1fact_mergebulge
     end do
     
     ! set G
-    G = 0d0
-    G(3) = -1d0
+    G(1) = 1d0/sqrt(3d0)
+    G(2) = 1d0/sqrt(3d0)
+    G(3) = 1d0/sqrt(3d0)
     
     ! set P
     P = .FALSE.
+    
+    ! initialize H1
+    call z_upr1fact_form_hess_matrix(N,P,Q,D,H1)
+    
+    temp(1,1) = cmplx(G(1),G(2),kind=8)
+    temp(2,1) = cmplx(G(3),0d0,kind=8)
+    temp(1,2) = -temp(2,1)
+    temp(2,2) = conjg(temp(1,1))
+    
+    H1(1:2,:) = matmul(temp,H1(1:2,:))
     
     ! call merge bulge
     call z_upr1fact_mergebulge('L',N,1,N-1,1,P,Q,D,G,INFO)
@@ -63,6 +76,14 @@ program test_z_upr1fact_mergebulge
     if (INFO.NE.0) then
       call u_test_failed(__LINE__)
     end if
+    
+    ! initialize H2
+    call z_upr1fact_form_hess_matrix(N,P,Q,D,H2)
+    
+    ! check difference
+    if (maxval(abs(H1-H2)) > tol) then
+      call u_test_failed(__LINE__)
+    end if 
   
   ! stop timer
   call system_clock(count=c_stop)
@@ -71,3 +92,56 @@ program test_z_upr1fact_mergebulge
   call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
 
 end program test_z_upr1fact_mergebulge
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This subroutine computes the (N+1)x(N+1) extended hessenberg matrix defined
+! by Given's rotations stored in Q whose order is described by P and the
+! diagonal matrix D. The output is stored in H.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine z_upr1fact_form_hess_matrix(N,P,Q,D,H)
+
+  implicit none
+  
+  ! input variables
+  integer, intent(in) :: N
+  logical, intent(in) :: P(N-2)
+  real(8), intent(in) :: Q(3*(N-1)), D(2*(N+1))
+  complex(8), intent(inout) :: H(N+1,N+1)
+  
+  ! compute variables
+  integer :: ii
+  complex :: temp(2,2)
+  
+  ! initialize H
+  H = cmplx(0d0,0d0,kind=8)
+  do ii=1,(N+1)
+    H(ii,ii) = cmplx(1d0,0d0,kind=8)
+  end do
+  H(1,1) = cmplx(Q(1),Q(2),kind=8)
+  H(2,1) = cmplx(Q(3),0d0,kind=8)
+  H(1,2) = -H(2,1)
+  H(2,2) = conjg(H(1,1))
+  
+  ! apply Q
+  do ii=1,(N-2)
+    temp(1,1) = cmplx(Q(3*ii+1),Q(3*ii+2),kind=8)
+    temp(2,1) = cmplx(Q(3*ii+3),0d0,kind=8)
+    temp(1,2) = -temp(2,1)
+    temp(2,2) = conjg(temp(1,1))
+    
+    if (P(ii).EQV..FALSE.) then
+      H(:,(ii+1):(ii+2)) = matmul(H(:,(ii+1):(ii+2)),temp)  
+    else
+      H((ii+1):(ii+2),:) = matmul(temp,H((ii+1):(ii+2),:))  
+    end if
+  
+  end do
+  
+  ! apply D
+  do ii=1,(N+1)
+    H(:,ii) = H(:,ii)*cmplx(D(2*ii-1),D(2*ii),kind=8)
+  end do
+  
+end subroutine z_upr1fact_form_hess_matrix

--- a/test/complex_double/test_z_upr1fact_mergebulge.f90
+++ b/test/complex_double/test_z_upr1fact_mergebulge.f90
@@ -1,0 +1,73 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_z_upr1fact_mergebulge
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine z_upr1fact_mergebulge. 
+! The following tests are run:
+!
+! 1) Q = [0, -1; 1, 0], P = FALSE, D = I, K = 1, JOB = L and 
+!    G = [0, 1; -1, 0]
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_z_upr1fact_mergebulge
+
+  implicit none
+  
+  ! compute variables
+  integer, parameter :: N = 3
+  integer :: ii
+  logical :: P(N-2)
+  real(8) :: Q(3*(N-1)),D(2*(N+1)), G(3)
+  integer :: INFO
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  ! check 1)
+    ! set INFO
+    INFO = 0
+  
+    ! set Q
+    Q = 0d0
+    do ii=1,(N-1)
+      Q(3*ii) = 1d0
+    end do
+    
+    ! set D
+    D = 0d0
+    do ii=1,(N+1)
+      D(2*ii-1) = 1d0
+    end do
+    
+    ! set G
+    G = 0d0
+    G(3) = -1d0
+    
+    ! set P
+    P = .FALSE.
+    
+    ! call merge bulge
+    call z_upr1fact_mergebulge('L',N,1,N-1,1,P,Q,D,G,INFO)
+  
+    ! check INFO
+    if (INFO.NE.0) then
+      call u_test_failed(__LINE__)
+    end if
+  
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+
+end program test_z_upr1fact_mergebulge


### PR DESCRIPTION
This PR changes the interface to z_upr1fact_deflationcheck to only take a 1D array for the diagonal D. It also changes the normalization to use the rot2 and rot3 generators.

The new routine for upr1fact is z_upr1fact_mergebulge. This routine performs a merge of a rotation into the unitary extended hessenberg part of a upr1 pencil.  