### PR TITLE
Fix upr1 infocodes

### DIFF
--- a/src/complex_double/z_upr1fact_2x2deflation.f90
+++ b/src/complex_double/z_upr1fact_2x2deflation.f90
@@ -52,6 +52,7 @@
 !                   if COMPZ = 'V' update W to store left schurvectors 
 !
 !  INFO           INTEGER
+!                   INFO = 1 implies subroutine failed
 !                   INFO = 0 implies successful computation
 !                   INFO = -1 implies ALG is invalid
 !                   INFO = -2 implies COMPZ is invalid
@@ -168,11 +169,9 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
   call z_upr1fact_2x2diagblocks('H',ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,A,B,INFO)
     
   ! check INFO in debug mode
-  if (DEBUG) then
-    call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_2x2diagblocks failed",INFO,INFO)
-    if (INFO.NE.0) then 
-      return 
-    end if 
+  if ((DEBUG).AND.(INFO.NE.0)) then
+    call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_2x2diagblocks failed",INFO,1)
+    return 
   end if
       
   ! compute standard Schur decomposition
@@ -182,22 +181,18 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     call z_2x2array_geneig('S',A,B,Wt,Vt,INFO)
       
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_2x2array_geneig failed",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_2x2array_geneig failed",INFO,1)
+      return 
     end if
     
     ! replace Vt with rotation G1
     call z_rot3_vec4gen(dble(Vt(1,1)),aimag(Vt(1,1)),dble(Vt(2,1)),aimag(Vt(2,1)),G1(1),G1(2),G1(3),nrm,INFO)
     
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen",INFO,1)
+      return 
     end if
     
     ! pass G1 through triangular factor
@@ -205,11 +200,9 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     call z_upr1fact_rot3throughtri('R2L',N,K,D1,C1,B1,G3,INFO)
     
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_rot3throughtri",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_rot3throughtri",INFO,1)
+      return 
     end if
     
     ! similarity transform of Q
@@ -270,33 +263,27 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     call z_2x2array_geneig('G',A,B,Wt,Vt,INFO)
       
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_2x2array_geneig failed",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_2x2array_geneig",INFO,1)
+      return 
     end if
     
     ! replace Vt with rotation G1
     call z_rot3_vec4gen(dble(Vt(1,1)),aimag(Vt(1,1)),dble(Vt(2,1)),aimag(Vt(2,1)),G1(1),G1(2),G1(3),nrm,INFO)
     
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen",INFO,1)
+      return 
     end if
     
     ! replace Wt with rotation G2
     call z_rot3_vec4gen(dble(Wt(1,1)),aimag(Wt(1,1)),dble(Wt(2,1)),aimag(Wt(2,1)),G2(1),G2(2),G2(3),nrm,INFO)
     
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen",INFO,INFO)
-      if (INFO.NE.0) then
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen",INFO,1)
+      return 
     end if
 
     ! pass G1 through right triangular factor
@@ -304,11 +291,9 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     call z_upr1fact_rot3throughtri('R2L',N,K,D2,C2,B2,G3,INFO)
     
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_rot3throughtri",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_rot3throughtri",INFO,1)
+      return 
     end if
     
     ! equivalence transform
@@ -344,11 +329,9 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     call z_upr1fact_rot3throughtri('R2L',N,K,D1,C1,B1,G3,INFO)
     
     ! check INFO in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_rot3throughtri",INFO,INFO)
-      if (INFO.NE.0) then 
-        return 
-      end if 
+    if ((DEBUG).AND.(INFO.NE.0)) then
+      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_rot3throughtri",INFO,1)
+      return 
     end if
     
     ! equivalence transform of Q

--- a/src/complex_double/z_upr1fact_2x2deflation.f90
+++ b/src/complex_double/z_upr1fact_2x2deflation.f90
@@ -98,39 +98,34 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     if (INFO.EQ.-1) then
       call u_infocode_check(__FILE__,__LINE__,"ALG must be 'QR' or 'QZ'",INFO,-1)
       return
-    end if
-    if (INFO.EQ.-2) then
+    else if (INFO.EQ.-2) then
       call u_infocode_check(__FILE__,__LINE__,"N is invalid",INFO,-3)
       return
-    end if
-    if (INFO.EQ.-3) then
+    else if (INFO.EQ.-3) then
       call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-6)
       return
-    end if
-    if (INFO.EQ.-4) then
+    else if (INFO.EQ.-4) then
       call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,-7)
       return
-    end if
-    if (INFO.EQ.-5) then
+    else if (INFO.EQ.-5) then
       call u_infocode_check(__FILE__,__LINE__,"C1 is invalid",INFO,-8)
       return
-    end if
-    if (INFO.EQ.-6) then
+    else if (INFO.EQ.-6) then
       call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,-9)
       return
-    end if
-    if (INFO.EQ.-7) then
+    else if (INFO.EQ.-7) then
       call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,-10)
       return
-    end if
-    if (INFO.EQ.-8) then
+    else if (INFO.EQ.-8) then
       call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,-11)
       return
-    end if
-    if (INFO.EQ.-9) then
+    else if (INFO.EQ.-9) then
       call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,-12)
       return
-    end if    
+    else if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_factorcheck failed",INFO,1)
+      return
+    end if   
     
     ! check K
     if ((K < 1).OR.(K > N-1)) then
@@ -152,7 +147,10 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
       if (INFO.NE.0) then
         call u_infocode_check(__FILE__,__LINE__,"V is invalid",INFO,-13)
         return
-      end if
+      else if (INFO.NE.0) then
+        call u_infocode_check(__FILE__,__LINE__,"z_2Darray_check failed",INFO,1)
+        return
+      end if 
     end if   
     
     ! check W
@@ -160,7 +158,11 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
       call z_2Darray_check(N,N,W,INFO)
       if (INFO.NE.0) then
         call u_infocode_check(__FILE__,__LINE__,"W is invalid",INFO,-14)
-      end if
+        return
+      else if (INFO.NE.0) then
+        call u_infocode_check(__FILE__,__LINE__,"z_2Darray_check failed",INFO,1)
+        return
+      end if 
     end if
     
   end if

--- a/src/complex_double/z_upr1fact_2x2deflation.f90
+++ b/src/complex_double/z_upr1fact_2x2deflation.f90
@@ -57,11 +57,15 @@
 !                   INFO = -2 implies COMPZ is invalid
 !                   INFO = -3 implies N is invalid
 !                   INFO = -4 implies K is invalid
-!                   INFO = -5 implies Q is invalid
-!                   INFO = -6 implies D is invalid
-!                   INFO = -7 implies R is invalid
-!                   INFO = -8 implies V is invalid
-!                   INFO = -9 implies W is invalid
+!                   INFO = -6 implies Q is invalid
+!                   INFO = -7 implies D1 is invalid
+!                   INFO = -8 implies C1 is invalid
+!                   INFO = -9 implies B1 is invalid
+!                   INFO = -10 implies D2 is invalid
+!                   INFO = -11 implies C2 is invalid
+!                   INFO = -12 implies B2 is invalid
+!                   INFO = -13 implies V is invalid
+!                   INFO = -14 implies W is invalid
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
@@ -99,17 +103,33 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
       return
     end if
     if (INFO.EQ.-3) then
-      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-5)
+      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-6)
       return
     end if
     if (INFO.EQ.-4) then
-      call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,-6)
+      call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,-7)
       return
     end if
     if (INFO.EQ.-5) then
-      call u_infocode_check(__FILE__,__LINE__,"R is invalid",INFO,-7)
+      call u_infocode_check(__FILE__,__LINE__,"C1 is invalid",INFO,-8)
       return
     end if
+    if (INFO.EQ.-6) then
+      call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,-9)
+      return
+    end if
+    if (INFO.EQ.-7) then
+      call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,-10)
+      return
+    end if
+    if (INFO.EQ.-8) then
+      call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,-11)
+      return
+    end if
+    if (INFO.EQ.-9) then
+      call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,-12)
+      return
+    end if    
     
     ! check K
     if ((K < 1).OR.(K > N-1)) then
@@ -129,7 +149,7 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     if (COMPZ.EQ.'V') then
       call z_2Darray_check(N,N,V,INFO)
       if (INFO.NE.0) then
-        call u_infocode_check(__FILE__,__LINE__,"V is invalid",INFO,-8)
+        call u_infocode_check(__FILE__,__LINE__,"V is invalid",INFO,-13)
         return
       end if
     end if   
@@ -138,7 +158,7 @@ subroutine z_upr1fact_2x2deflation(ALG,COMPZ,N,K,P,Q,D1,C1,B1,D2,C2,B2,V,W,INFO)
     if ((ALG.EQ.'QZ').AND.(COMPZ.EQ.'V')) then
       call z_2Darray_check(N,N,W,INFO)
       if (INFO.NE.0) then
-        call u_infocode_check(__FILE__,__LINE__,"W is invalid",INFO,-9)
+        call u_infocode_check(__FILE__,__LINE__,"W is invalid",INFO,-14)
       end if
     end if
     

--- a/src/complex_double/z_upr1fact_2x2diagblocks.f90
+++ b/src/complex_double/z_upr1fact_2x2diagblocks.f90
@@ -48,7 +48,7 @@
 !                   the upper-triangular matrix
 !
 !  INFO           INTEGER
-!                   INFO = 1 implies successful computation
+!                   INFO = 1 implies subroutine failed
 !                   INFO = 0 implies successful computation
 !                   INFO = -1 implies JOB is invalid
 !                   INFO = -2 implies ALG is invalid

--- a/src/complex_double/z_upr1fact_2x2diagblocks.f90
+++ b/src/complex_double/z_upr1fact_2x2diagblocks.f90
@@ -49,8 +49,17 @@
 !
 !  INFO           INTEGER
 !                   INFO = 0 implies successful computation
-!                   INFO = -1 implies ALG, N, Q, D or R is invalid
-!                   INFO = -2 implies K is invalid
+!                   INFO = -1 implies JOB is invalid
+!                   INFO = -2 implies ALG is invalid
+!                   INFO = -3 implies N is invalid
+!                   INFO = -4 implies K is invalid
+!                   INFO = -6 implies Q is invalid
+!                   INFO = -7 implies D1 is invalid
+!                   INFO = -8 implies C1 is invalid
+!                   INFO = -9 implies B1 is invalid
+!                   INFO = -10 implies D2 is invalid
+!                   INFO = -11 implies C2 is invalid
+!                   INFO = -12 implies B2 is invalid
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine z_upr1fact_2x2diagblocks(JOB,ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,A,B,INFO)
@@ -79,15 +88,46 @@ subroutine z_upr1fact_2x2diagblocks(JOB,ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,A,B,INFO)
     
     ! check factorization
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
-    if (INFO.NE.0) then
-      call u_infocode_check(__FILE__,__LINE__,"ALG, N, Q, D or R is invalid",INFO,INFO)
-      INFO = -1
+    if (INFO.EQ.-1) then
+      call u_infocode_check(__FILE__,__LINE__,"ALG must be 'QR' or 'QZ'",INFO,-1)
       return
     end if
+    if (INFO.EQ.-2) then
+      call u_infocode_check(__FILE__,__LINE__,"N is invalid",INFO,-3)
+      return
+    end if
+    if (INFO.EQ.-3) then
+      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-6)
+      return
+    end if
+    if (INFO.EQ.-4) then
+      call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,-7)
+      return
+    end if
+    if (INFO.EQ.-5) then
+      call u_infocode_check(__FILE__,__LINE__,"C1 is invalid",INFO,-8)
+      return
+    end if
+    if (INFO.EQ.-6) then
+      call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,-9)
+      return
+    end if
+    if (INFO.EQ.-7) then
+      call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,-10)
+      return
+    end if
+    if (INFO.EQ.-8) then
+      call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,-11)
+      return
+    end if
+    if (INFO.EQ.-9) then
+      call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,-12)
+      return
+    end if    
     
     ! check K
     if ((K < 1).OR.(K > N-1)) then
-      INFO = -2
+      INFO = -4
       call u_infocode_check(__FILE__,__LINE__,"K must 1 <= K <= N-1",INFO,INFO)
       return
     end if 

--- a/src/complex_double/z_upr1fact_2x2diagblocks.f90
+++ b/src/complex_double/z_upr1fact_2x2diagblocks.f90
@@ -48,6 +48,7 @@
 !                   the upper-triangular matrix
 !
 !  INFO           INTEGER
+!                   INFO = 1 implies successful computation
 !                   INFO = 0 implies successful computation
 !                   INFO = -1 implies JOB is invalid
 !                   INFO = -2 implies ALG is invalid
@@ -91,39 +92,34 @@ subroutine z_upr1fact_2x2diagblocks(JOB,ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,A,B,INFO)
     if (INFO.EQ.-1) then
       call u_infocode_check(__FILE__,__LINE__,"ALG must be 'QR' or 'QZ'",INFO,-1)
       return
-    end if
-    if (INFO.EQ.-2) then
+    else if (INFO.EQ.-2) then
       call u_infocode_check(__FILE__,__LINE__,"N is invalid",INFO,-3)
       return
-    end if
-    if (INFO.EQ.-3) then
+    else if (INFO.EQ.-3) then
       call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-6)
       return
-    end if
-    if (INFO.EQ.-4) then
+    else if (INFO.EQ.-4) then
       call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,-7)
       return
-    end if
-    if (INFO.EQ.-5) then
+    else if (INFO.EQ.-5) then
       call u_infocode_check(__FILE__,__LINE__,"C1 is invalid",INFO,-8)
       return
-    end if
-    if (INFO.EQ.-6) then
+    else if (INFO.EQ.-6) then
       call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,-9)
       return
-    end if
-    if (INFO.EQ.-7) then
+    else if (INFO.EQ.-7) then
       call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,-10)
       return
-    end if
-    if (INFO.EQ.-8) then
+    else if (INFO.EQ.-8) then
       call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,-11)
       return
-    end if
-    if (INFO.EQ.-9) then
+    else if (INFO.EQ.-9) then
       call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,-12)
       return
-    end if    
+    else if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_factorcheck failed",INFO,1)
+      return
+    end if   
     
     ! check K
     if ((K < 1).OR.(K > N-1)) then

--- a/src/complex_double/z_upr1fact_buildbulge.f90
+++ b/src/complex_double/z_upr1fact_buildbulge.f90
@@ -47,14 +47,19 @@
 !                    transformation
 !
 !  INFO            INTEGER
+!                   INFO = 1 implies subroutine failed
 !                   INFO = 0 implies successful computation
 !                   INFO = -1 implies ALG is invalid
 !                   INFO = -2 implies N is invalid
 !                   INFO = -3 implies K is invalid
 !                   INFO = -5 implies Q is invalid
-!                   INFO = -6 implies D is invalid
-!                   INFO = -7 implies R is invalid
-!                   INFO = -8 implies SHFT is invalid
+!                   INFO = -6 implies D1 is invalid
+!                   INFO = -7 implies C1 is invalid
+!                   INFO = -8 implies B1 is invalid
+!                   INFO = -9 implies D2 is invalid
+!                   INFO = -10 implies C2 is invalid
+!                   INFO = -11 implies B2 is invalid
+!                   INFO = -12 implies SHFT is invalid
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine z_upr1fact_buildbulge(ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,SHFT,G,INFO)
@@ -96,30 +101,46 @@ subroutine z_upr1fact_buildbulge(ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,SHFT,G,INFO)
       return
     end if
     if (INFO.EQ.-4) then
-      call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,-6)
+      call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,-6)
       return
     end if
     if (INFO.EQ.-5) then
-      call u_infocode_check(__FILE__,__LINE__,"R is invalid",INFO,-7)
+      call u_infocode_check(__FILE__,__LINE__,"C1 is invalid",INFO,-7)
       return
     end if
+    if (INFO.EQ.-6) then
+      call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,-8)
+      return
+    end if
+    if (INFO.EQ.-7) then
+      call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,-9)
+      return
+    end if
+    if (INFO.EQ.-8) then
+      call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,-10)
+      return
+    end if
+    if (INFO.EQ.-9) then
+      call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,-11)
+      return
+    end if    
     
     ! check K
     if ((K < 1).OR.(K >= N-1)) then
       INFO = -3
       call u_infocode_check(__FILE__,__LINE__,"K must 1 <= K < N-1",INFO,INFO)
       return
-    end if 
+    end if  
   
     ! check SHFT
     call z_scalar_nancheck(SHFT,INFO)
     if (INFO.NE.0) then
-      call u_infocode_check(__FILE__,__LINE__,"SHFT is invalid",INFO,-8)
+      call u_infocode_check(__FILE__,__LINE__,"SHFT is invalid",INFO,-12)
       return
     end if
     call z_scalar_infcheck(SHFT,INFO)
     if (INFO.NE.0) then
-      call u_infocode_check(__FILE__,__LINE__,"SHFT is invalid",INFO,-8)
+      call u_infocode_check(__FILE__,__LINE__,"SHFT is invalid",INFO,-12)
       return
     end if
   
@@ -129,11 +150,9 @@ subroutine z_upr1fact_buildbulge(ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,SHFT,G,INFO)
   call z_upr1fact_2x2diagblocks('T',ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,A,B,INFO)
       
   ! check INFO in debug mode
-  if (DEBUG) then
+  if ((DEBUG).AND.(INFO.NE.0)) then
     call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_2x2diagblocks failed",INFO,1)
-    if (INFO.NE.0) then 
-      return 
-    end if 
+    return 
   end if
   
   ! compute first columns
@@ -172,11 +191,9 @@ subroutine z_upr1fact_buildbulge(ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,SHFT,G,INFO)
   call z_rot3_vec4gen(dble(vec1(1)),aimag(vec1(1)),dble(vec1(2)),aimag(vec1(2)),G(1),G(2),G(3),nrm,INFO)
       
   ! check INFO in debug mode
-  if (DEBUG) then
+  if ((DEBUG).AND.(INFO.NE.0)) then
     call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec4gen failed",INFO,1)
-    if (INFO.NE.0) then 
-      return 
-    end if 
+    return 
   end if
 
 end subroutine z_upr1fact_buildbulge

--- a/src/complex_double/z_upr1fact_buildbulge.f90
+++ b/src/complex_double/z_upr1fact_buildbulge.f90
@@ -91,39 +91,34 @@ subroutine z_upr1fact_buildbulge(ALG,N,K,P,Q,D1,C1,B1,D2,C2,B2,SHFT,G,INFO)
     if (INFO.EQ.-1) then
       call u_infocode_check(__FILE__,__LINE__,"ALG must be 'QR' or 'QZ'",INFO,-1)
       return
-    end if
-    if (INFO.EQ.-2) then
+    else if (INFO.EQ.-2) then
       call u_infocode_check(__FILE__,__LINE__,"N is invalid",INFO,-2)
       return
-    end if
-    if (INFO.EQ.-3) then
+    else if (INFO.EQ.-3) then
       call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-5)
       return
-    end if
-    if (INFO.EQ.-4) then
+    else if (INFO.EQ.-4) then
       call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,-6)
       return
-    end if
-    if (INFO.EQ.-5) then
+    else if (INFO.EQ.-5) then
       call u_infocode_check(__FILE__,__LINE__,"C1 is invalid",INFO,-7)
       return
-    end if
-    if (INFO.EQ.-6) then
+    else if (INFO.EQ.-6) then
       call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,-8)
       return
-    end if
-    if (INFO.EQ.-7) then
+    else if (INFO.EQ.-7) then
       call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,-9)
       return
-    end if
-    if (INFO.EQ.-8) then
+    else if (INFO.EQ.-8) then
       call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,-10)
       return
-    end if
-    if (INFO.EQ.-9) then
+    else if (INFO.EQ.-9) then
       call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,-11)
       return
-    end if    
+    else if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"z_upr1fact_factorcheck failed",INFO,1)
+      return
+    end if  
     
     ! check K
     if ((K < 1).OR.(K >= N-1)) then

--- a/src/complex_double/z_upr1fact_deflationcheck.f90
+++ b/src/complex_double/z_upr1fact_deflationcheck.f90
@@ -49,11 +49,11 @@
 !                    Contains the number of iterations per deflation
 !
 !  INFO            INTEGER
+!                   INFO = 1 implies subroutine failed
 !                   INFO = 0 implies successful computation
 !                   INFO = -1 implies N is invalid
 !                   INFO = -2 implies STR is invalid
 !                   INFO = -3 implies STP is invalid
-!                   INFO = -4 implies ZERO is invalid
 !                   INFO = -6 implies Q is invalid
 !                   INFO = -7 implies D is invalid
 !                   INFO = -8 implies ITCNT is invalid
@@ -81,9 +81,18 @@ subroutine z_upr1fact_deflationcheck(N,STR,STP,ZERO,P,Q,D,ITCNT,ITS,INFO)
   if (DEBUG) then
     
     ! check N
-    if (N < 2) then
-      INFO = -1
-      call u_infocode_check(__FILE__,__LINE__,"N must be at least 2",INFO,INFO)
+    call z_unifact_factorcheck(N,Q,D,INFO)
+    if (INFO.EQ.-1) then
+      call u_infocode_check(__FILE__,__LINE__,"N is invalid",INFO,-1)
+      return
+    else if (INFO.EQ.-2) then
+      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-6)
+      return
+    else if (INFO.EQ.-3) then
+      call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,-7)
+      return
+    else if (INFO.NE.0) then
+      call u_infocode_check(__FILE__,__LINE__,"z_unifact_factorcheck failed",INFO,1)
       return
     end if
     
@@ -100,27 +109,6 @@ subroutine z_upr1fact_deflationcheck(N,STR,STP,ZERO,P,Q,D,ITCNT,ITS,INFO)
       call u_infocode_check(__FILE__,__LINE__,"STP must STR <= STP <= N-1",INFO,INFO)
       return
     end if  
-    
-    ! check ZERO
-    if ((ZERO >= STR).OR.(ZERO < 0)) then
-      INFO = -4
-      call u_infocode_check(__FILE__,__LINE__,"ZERO must 0 <= ZERO < STR",INFO,INFO)
-      return
-    end if  
-    
-    ! check Q
-    call d_1Darray_check(3*(N-1),Q,INFO)
-    if (INFO.NE.0) then
-      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,-6)
-      return
-    end if
-
-    ! check D
-    call d_1Darray_check(2*(N+1),D,INFO)
-    if (INFO.NE.0) then
-      call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,-7)
-      return
-    end if
     
     ! check ITCNT
     if (ITCNT < 0) then
@@ -177,11 +165,9 @@ subroutine z_upr1fact_deflationcheck(N,STR,STP,ZERO,P,Q,D,ITCNT,ITS,INFO)
         call z_rot3_vec3gen(cr,ci,s,Q(3*up-2),Q(3*up-1),Q(3*up),nrm,INFO)
         
         ! check INFO in debug mode
-        if (DEBUG) then
-          call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec3gen failed",INFO,INFO)
-          if (INFO.NE.0) then 
-            return 
-          end if 
+        if ((DEBUG).AND.(INFO.NE.0)) then
+          call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec3gen failed",INFO,1)
+          return 
         end if
         
       end do
@@ -197,12 +183,10 @@ subroutine z_upr1fact_deflationcheck(N,STR,STP,ZERO,P,Q,D,ITCNT,ITS,INFO)
       call d_rot2_vec2gen(dr,di,D(2*up-1),D(2*up),nrm,INFO)
 
       ! check INFO in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
-        if (INFO.NE.0) then 
-          return 
-        end if 
-      end if    
+      if ((DEBUG).AND.(INFO.NE.0)) then
+        call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,1)
+        return 
+      end if   
     
       ! initialize downward index
       down = ind
@@ -230,12 +214,10 @@ subroutine z_upr1fact_deflationcheck(N,STR,STP,ZERO,P,Q,D,ITCNT,ITS,INFO)
         call z_rot3_vec3gen(cr,ci,s,Q(3*down-2),Q(3*down-1),Q(3*down),nrm,INFO)
         
         ! check INFO in debug mode
-        if (DEBUG) then
-          call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec3gen failed",INFO,INFO)
-          if (INFO.NE.0) then 
-            return 
-          end if 
-        end if
+        if ((DEBUG).AND.(INFO.NE.0)) then
+          call u_infocode_check(__FILE__,__LINE__,"z_rot3_vec3gen failed",INFO,1)
+          return 
+        end if 
                     
       end do
       
@@ -253,12 +235,10 @@ subroutine z_upr1fact_deflationcheck(N,STR,STP,ZERO,P,Q,D,ITCNT,ITS,INFO)
       call d_rot2_vec2gen(dr,di,D(2*down-1),D(2*down),nrm,INFO)
 
       ! check INFO in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
-        if (INFO.NE.0) then 
-          return 
-        end if 
-      end if  
+      if ((DEBUG).AND.(INFO.NE.0)) then
+        call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,1)
+        return 
+      end if    
       
       ! update indices
       ZERO = STP+1-ii

--- a/src/complex_double/z_upr1fact_factorcheck.f90
+++ b/src/complex_double/z_upr1fact_factorcheck.f90
@@ -34,12 +34,17 @@
 ! OUTPUT VARIABLES:
 !
 !  INFO           INTEGER
+!                   INFO = 1 implies subroutine failed
 !                   INFO = 0 implies valid factorization
 !                   INFO = -1 implies ALG is invalid
 !                   INFO = -2 implies N is invalid
 !                   INFO = -3 implies Q is invalid
-!                   INFO = -4 implies D is invalid
-!                   INFO = -5 implies R is invalid
+!                   INFO = -4 implies D1 is invalid
+!                   INFO = -5 implies C1 is invalid
+!                   INFO = -6 implies B1 is invalid
+!                   INFO = -7 implies D2 is invalid
+!                   INFO = -8 implies C2 is invalid
+!                   INFO = -9 implies B2 is invalid
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
@@ -102,56 +107,32 @@ subroutine z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
         call u_infocode_check(__FILE__,__LINE__,"Q is not unitary",INFO,INFO)
       end if
       return
-   end if
+    end if
   end do
   
-  ! check D
+  ! check D1 for INFs or NANs
   call d_1Darray_check(2*(N+1),D1,INFO)
   if (INFO.NE.0) then
     ! print error message in debug mode
     if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,INFO)
+      call u_infocode_check(__FILE__,__LINE__,"D1 is invalid",INFO,INFO)
     end if
     INFO = -4
     return
   end if
-  if (ALG.EQ.'QZ') then
-    call d_1Darray_check(2*(N+1),D2,INFO)
-    if (INFO.NE.0) then
-      ! print error message in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,INFO)
-      end if
-      INFO = -4
-      return
-    end if
-  end if
-  
-  ! check D for orthogonality
+
+  ! check D1 for orthogonality
   do ii=1,(N+1)
     nrm = sqrt(D1(2*ii-1)**2 + D1(2*ii)**2)
     if (abs(nrm-1d0) > tol) then
       INFO = -4
       ! print error message in debug mode
       if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"D is not unitary",INFO,INFO)
+        call u_infocode_check(__FILE__,__LINE__,"D1 is not unitary",INFO,INFO)
       end if
       return
-   end if
-  end do
-  if (ALG.EQ.'QZ') then
-    do ii=1,(N+1)
-      nrm = sqrt(D2(2*ii-1)**2 + D2(2*ii)**2)
-      if (abs(nrm-1d0) > tol) then
-        INFO = -4
-        ! print error message in debug mode
-        if (DEBUG) then
-          call u_infocode_check(__FILE__,__LINE__,"D is not unitary",INFO,INFO)
-        end if
-        return
-     end if
-    end do
-  end if
+    end if
+  end do  
   
   ! check C1 for NANs and INFs
   call d_1Darray_check(3*N,C1,INFO)
@@ -164,43 +145,6 @@ subroutine z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     return
   end if
   
-  ! check B1 for NANs and INFs
-  call d_1Darray_check(3*N,B1,INFO)
-  if (INFO.NE.0) then
-    ! print error message in debug mode
-    if (DEBUG) then
-      call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,INFO)
-    end if
-    INFO = -5
-    return
-  end if
-  
-  ! check C2 for NANs and INFs  
-  if (ALG.EQ.'QZ') then
-    call d_1Darray_check(3*N,C2,INFO)
-    if (INFO.NE.0) then
-      ! print error message in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,INFO)
-      end if
-      INFO = -5
-      return
-    end if
-  end if
-  
-  ! check B2 for NANs and INFs  
-  if (ALG.EQ.'QZ') then
-    call d_1Darray_check(3*N,B2,INFO)
-    if (INFO.NE.0) then
-      ! print error message in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,INFO)
-      end if
-      INFO = -5
-      return
-    end if
-  end if
-  
   ! check C1 for orthogonality
   do ii=1,N
     nrm = sqrt(C1(3*ii-2)**2 + C1(3*ii-1)**2 + C1(3*ii)**2)
@@ -211,75 +155,8 @@ subroutine z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
         call u_infocode_check(__FILE__,__LINE__,"C1 is not unitary",INFO,INFO)
       end if
       return
-   end if
+    end if
   end do
-  
-  ! check B1 for orthogonality
-  do ii=1,N
-    nrm = sqrt(B1(3*ii-2)**2 + B1(3*ii-1)**2 + B1(3*ii)**2)
-    if (abs(nrm-1d0) > tol) then
-      INFO = -5
-      ! print error message in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"B1 is not unitary",INFO,INFO)
-      end if
-      return
-   end if
-  end do
-  
-  ! check C2 for orthogonality
-  if (ALG.EQ.'QZ') then
-    do ii=1,N
-      nrm = sqrt(C2(3*ii-2)**2 + C2(3*ii-1)**2 + C2(3*ii)**2)
-      if (abs(nrm-1d0) > tol) then
-        INFO = -5
-        ! print error message in debug mode
-        if (DEBUG) then
-          call u_infocode_check(__FILE__,__LINE__,"C2 is not unitary",INFO,INFO)
-        end if
-        return
-     end if
-    end do
-    
-  ! check B2 for orthogonality
-    do ii=1,N
-      nrm = sqrt(B2(3*ii-2)**2 + B2(3*ii-1)**2 + B2(3*ii)**2)
-      if (abs(nrm-1d0) > tol) then
-        INFO = -5
-        ! print error message in debug mode
-        if (DEBUG) then
-          call u_infocode_check(__FILE__,__LINE__,"B2 is not unitary",INFO,INFO)
-        end if
-        return
-     end if
-    end do  
-  end if
-  
-  ! check B1 for zero diagonal elements
-  do ii=1,N
-    if (abs(B1(3*ii)) <= tol) then
-      INFO = -5
-      ! print error message in debug mode
-      if (DEBUG) then
-        call u_infocode_check(__FILE__,__LINE__,"B1 has a zero diagonal element",INFO,INFO)
-      end if
-      return
-   end if
-  end do
-  
-  ! check B2 for zero diagonal elements
-  if (ALG.EQ.'QZ') then  
-    do ii=1,N
-      if (abs(B2(3*ii)) <= tol) then
-        INFO = -5
-        ! print error message in debug mode
-        if (DEBUG) then
-          call u_infocode_check(__FILE__,__LINE__,"B2 has a zero diagonal element",INFO,INFO)
-        end if
-        return
-     end if
-    end do
-  end if
   
   ! check C1 for inf diagonal elements
   do ii=1,N
@@ -290,14 +167,100 @@ subroutine z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
         call u_infocode_check(__FILE__,__LINE__,"C1 has an infinite diagonal element",INFO,INFO)
       end if
       return
-   end if
+    end if
   end do
   
-  ! check C2 for inf diagonal elements
-  if (ALG.EQ.'QZ') then  
+  ! check B1 for NANs and INFs
+  call d_1Darray_check(3*N,B1,INFO)
+  if (INFO.NE.0) then
+    ! print error message in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"B1 is invalid",INFO,INFO)
+    end if
+    INFO = -6
+    return
+  end if
+  
+  ! check B1 for orthogonality
+  do ii=1,N
+    nrm = sqrt(B1(3*ii-2)**2 + B1(3*ii-1)**2 + B1(3*ii)**2)
+    if (abs(nrm-1d0) > tol) then
+      INFO = -6
+      ! print error message in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"B1 is not unitary",INFO,INFO)
+      end if
+      return
+    end if
+  end do
+  
+  ! check B1 for zero diagonal elements
+  do ii=1,N
+    if (abs(B1(3*ii)) <= tol) then
+      INFO = -6
+      ! print error message in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"B1 has a zero diagonal element",INFO,INFO)
+      end if
+      return
+    end if
+  end do
+  
+  ! check D2, C2, B2 if ALG == QZ
+  if (ALG.EQ.'QZ') then
+  
+    ! check D2 for INFs or NANs
+    call d_1Darray_check(2*(N+1),D2,INFO)
+    if (INFO.NE.0) then
+      ! print error message in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"D2 is invalid",INFO,INFO)
+      end if
+      INFO = -7
+      return
+    end if
+  
+    ! check D2 for orthogonality
+    do ii=1,(N+1)
+      nrm = sqrt(D2(2*ii-1)**2 + D2(2*ii)**2)
+      if (abs(nrm-1d0) > tol) then
+        INFO = -7
+        ! print error message in debug mode
+        if (DEBUG) then
+          call u_infocode_check(__FILE__,__LINE__,"D2 is not unitary",INFO,INFO)
+        end if
+        return
+      end if
+    end do
+  
+   ! check C2 for NANs and INFs  
+    call d_1Darray_check(3*N,C2,INFO)
+    if (INFO.NE.0) then
+      ! print error message in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"C2 is invalid",INFO,INFO)
+      end if
+      INFO = -8
+      return
+    end if
+    
+    ! check C2 for orthogonality
+    do ii=1,N
+      nrm = sqrt(C2(3*ii-2)**2 + C2(3*ii-1)**2 + C2(3*ii)**2)
+      if (abs(nrm-1d0) > tol) then
+        INFO = -8
+        ! print error message in debug mode
+        if (DEBUG) then
+          call u_infocode_check(__FILE__,__LINE__,"C2 is not unitary",INFO,INFO)
+        end if
+        return
+      end if
+    end do
+     
+    ! check C2 for inf diagonal elements
     do ii=1,N
       if (abs(C2(3*ii)) <= tol) then
-        INFO = -5
+        INFO = -8
         ! print error message in debug mode
         if (DEBUG) then
           call u_infocode_check(__FILE__,__LINE__,"C2 has an infinite diagonal element",INFO,INFO)
@@ -305,6 +268,43 @@ subroutine z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
         return
      end if
     end do
-  end if
   
+   ! check B2 for NANs and INFs  
+    call d_1Darray_check(3*N,B2,INFO)
+    if (INFO.NE.0) then
+      ! print error message in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"B2 is invalid",INFO,INFO)
+      end if
+      INFO = -9
+      return
+    end if
+ 
+    ! check B2 for orthogonality
+    do ii=1,N
+      nrm = sqrt(B2(3*ii-2)**2 + B2(3*ii-1)**2 + B2(3*ii)**2)
+      if (abs(nrm-1d0) > tol) then
+        INFO = -9
+        ! print error message in debug mode
+        if (DEBUG) then
+          call u_infocode_check(__FILE__,__LINE__,"B2 is not unitary",INFO,INFO)
+        end if
+        return
+     end if
+    end do  
+
+    ! check B2 for zero diagonal elements
+    do ii=1,N
+      if (abs(B2(3*ii)) <= tol) then
+        INFO = -9
+        ! print error message in debug mode
+        if (DEBUG) then
+          call u_infocode_check(__FILE__,__LINE__,"B2 has a zero diagonal element",INFO,INFO)
+        end if
+        return
+     end if
+    end do
+  
+  end if 
+
 end subroutine z_upr1fact_factorcheck

--- a/test/complex_double/test_z_upr1fact_factorcheck.f90
+++ b/test/complex_double/test_z_upr1fact_factorcheck.f90
@@ -180,7 +180,7 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-4) then
+    if (INFO.NE.-7) then
       call u_test_failed(__LINE__)
     end if 
     
@@ -198,11 +198,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-4) then
+    if (INFO.NE.-7) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset D
+    ! reset D2
     D2(1) = 1d0
     
   ! check 9)
@@ -216,11 +216,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-4) then
+    if (INFO.NE.-7) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset D
+    ! reset D2
     D2(2) = 0d0
     
   ! check 10)
@@ -234,11 +234,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-5) then
+    if (INFO.NE.-8) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset R
+    ! reset C2
     C2(1) = 1d0
     
   ! check 11)
@@ -252,11 +252,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-5) then
+    if (INFO.NE.-8) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset R
+    ! reset C2
     C2(1) = 1d0
     
   ! check 12)
@@ -270,11 +270,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-5) then
+    if (INFO.NE.-8) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset R
+    ! reset C2
     C2(1) = 0d0
     
   ! check 13)
@@ -289,11 +289,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-5) then
+    if (INFO.NE.-9) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset R
+    ! reset B2
     B2(1) = 0d0
     B2(3) = 1d0
   
@@ -309,11 +309,11 @@ program test_z_upr1fact_factorcheck
     call z_upr1fact_factorcheck(ALG,N,Q,D1,C1,B1,D2,C2,B2,INFO)
     
     ! check INFO
-    if (INFO.NE.-5) then
+    if (INFO.NE.-8) then
       call u_test_failed(__LINE__)
     end if 
     
-    ! reset R
+    ! reset C2
     C2(1) = 0d0
     C2(3) = 1d0
   


### PR DESCRIPTION
This pull request updates the info code checks for 4 of the upr1 subroutines. Two new features are that it has a catch all (INFO.NE.0) statement added to the factorcheck calls and INFO is set to 1 whenever a subroutine failure is detected.