### PR TITLE
Set core subroutines

### DIFF
--- a/src/complex_double/z_unifact_deflationcheck.f90
+++ b/src/complex_double/z_unifact_deflationcheck.f90
@@ -45,6 +45,9 @@ subroutine z_unifact_deflationcheck(N,Q,D,ZERO)
   integer :: ii, jj, down
   real(8), parameter :: tol = EISCOR_DBL_EPS
   real(8) :: dr, di, qr, qi, s, nrm
+
+  ! intialize ZERO
+  ZERO = 0
   
   ! check for deflation
   do ii=1,(N-1)

--- a/src/complex_double/z_unihess_qr.f90
+++ b/src/complex_double/z_unihess_qr.f90
@@ -59,7 +59,7 @@ subroutine z_unihess_qr(VEC,ID,N,H,WORK,M,Z,ITS,INFO)
   integer, intent(in) :: N, M
   real(8), intent(inout) :: WORK(5*N)
   integer, intent(inout) :: ITS(N-1), INFO
-  complex(8), intent(inout) :: H(N,N), Z(N,N)
+  complex(8), intent(inout) :: H(N,N), Z(M,N)
   
   ! compute variables
   integer :: ii

--- a/src/double/d_2x2array_eig.f90
+++ b/src/double/d_2x2array_eig.f90
@@ -40,7 +40,7 @@ subroutine d_2x2array_eig(FLAG,A,B,Q,Z)
   ! compute variables
   integer :: ii, id
   real(8) :: trace, disc, detm, temp
-  real(8) :: p0, p1 ,p2, T(2,2)
+  real(8) :: c, s, nrm, T(2,2)
  
   ! B not identity
   if (FLAG) then
@@ -123,107 +123,7 @@ subroutine d_2x2array_eig(FLAG,A,B,Q,Z)
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! this section needs finishing
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      ! compute polynomial coefficients
-      p2 = B(1,1)*B(2,2)
-      p1 = A(2,1)*B(1,2) - (A(1,1)*B(2,2)+A(2,2)*B(1,1))
-      p0 = A(1,1)*A(2,2) - A(2,1)*A(1,2)  
-  
-      ! compute intermediate values
-      disc = sqrt(p1**2 - 4d0*p2*p0)
-  
-    ! imaginary roots
-    if (temp < 0) then
-      
-      ! move A to standard form (A(1,1) = A(2,2))
-      ! real part of lambda
-      trace = trace/2d0
-    
-      ! imaginary part of lambda 
-      disc = sqrt(-temp)/2d0
-   
-      ! compute Q
-      temp = (A(2,2)-A(1,1))
-      if ((temp.NE.0).AND.(abs(temp)>1)) then
-        temp = (A(1,2)+A(2,1))/temp
-        temp = temp*(1d0-sqrt(1d0+1d0/temp/temp))
-      else if (temp.NE.0) then 
-        temp = (A(1,2)+A(2,1))/temp
-        temp = temp-sqrt(1d0+temp*temp)
-      end if
-      call d_rot2_vec2gen(1d0,temp,Q(1,1),Q(2,1),temp)
-      Q(2,2) = Q(1,1)
-      Q(1,2) = -Q(2,1)
-    
-      ! update A
-      A = matmul(transpose(Q),matmul(A,Q))
-
-    ! real roots
-    else
-     
-      ! sqrt of discriminant 
-      disc = sqrt(temp)
-      
-      ! compute most accurate eigenvalue
-      if(abs(trace+disc) > abs(trace-disc))then
-        temp = (trace+disc)/2d0
-      else
-        temp = (trace-disc)/2d0
-      end if
-
-      ! compute Schur vectors
-      call d_rot2_vec2gen(A(1,2),temp-A(1,1),Q(1,1),Q(2,1),trace)
-      Q(2,2) = Q(1,1)
-      Q(1,2) = -Q(2,1)
-      
-      ! update A
-      A(1,1) = temp
-      A(1,2) = 0d0
-      A(2,2) = detm/temp
-      A(2,1) = 0d0
-      
-    end if
-
-      ! create eliminator
-      call d_rot2_vec2gen(T(1,1),T(1,2),c,s,nrm)
-      
-      ! store in T
-      T(1,1) = -s
-      T(2,1) = c
-      T(1,2) = c
-      T(2,2) = s
-  
-      ! update A
-      A = matmul(A,T)
-  
-      ! update B
-      B = matmul(B,T)
-  
-      ! update Z
-      Z = matmul(Z,T)
-  
-      ! return to upper-triangular form  
-      ! create eliminator
-      call d_rot2_vec2gen(A(1,1),A(2,1),c,s,nrm)
-      
-      ! store in T
-      T(1,1) = c
-      T(2,1) = s
-      T(1,2) = -s
-      T(2,2) = c
-  
-      ! update A
-      A = matmul(transpose(T),A)
-      A(2,1) = 0d0
-  
-      ! update B
-      B = matmul(transpose(T),B)
-      B(2,1) = 0d0
-  
-      ! update Q 
-      Q = matmul(Q,T)
-
-    end if
-  
+    end if 
   ! B identity
   else  
 
@@ -236,27 +136,34 @@ subroutine d_2x2array_eig(FLAG,A,B,Q,Z)
     if (temp < 0) then
       
       ! move A to standard form (A(1,1) = A(2,2))
-      ! real part of lambda
-      trace = trace/2d0
-    
-      ! imaginary part of lambda 
-      disc = sqrt(-temp)/2d0
    
       ! compute Q
       temp = (A(2,2)-A(1,1))
-      if ((temp.NE.0).AND.(abs(temp)>1)) then
+      if (temp.NE.0) then
+        
         temp = (A(1,2)+A(2,1))/temp
-        temp = temp*(1d0-sqrt(1d0+1d0/temp/temp))
-      else if (temp.NE.0) then 
-        temp = (A(1,2)+A(2,1))/temp
-        temp = temp-sqrt(1d0+temp*temp)
+
+        if (abs(temp) > 1d0) then
+          temp = temp*(1d0+sqrt(1d0+1d0/temp/temp))
+          call d_rot2_vec2gen(temp,1d0,Q(1,1),Q(2,1),temp)
+        else 
+          temp = temp+sign(1d0,temp)*sqrt(1d0+temp*temp)
+          call d_rot2_vec2gen(temp,1d0,Q(1,1),Q(2,1),temp)
+        end if
+
+      else
+
+        Q(1,1) = 1d0
+        Q(2,1) = 0d0
+
       end if
-      call d_rot2_vec2gen(1d0,temp,Q(1,1),Q(2,1),temp)
+
       Q(2,2) = Q(1,1)
       Q(1,2) = -Q(2,1)
-    
+
       ! update A
-      A = matmul(transpose(Q),matmul(A,Q))
+      A = matmul(A,Q)
+      A = matmul(transpose(Q),A)
 
     ! real roots
     else
@@ -277,9 +184,7 @@ subroutine d_2x2array_eig(FLAG,A,B,Q,Z)
       Q(1,2) = -Q(2,1)
       
       ! update A
-      A(1,1) = temp
-      A(1,2) = 0d0
-      A(2,2) = detm/temp
+      A = matmul(transpose(Q),matmul(A,Q))
       A(2,1) = 0d0
       
     end if

--- a/src/double/d_orthfact_2x2deflation.f90
+++ b/src/double/d_orthfact_2x2deflation.f90
@@ -1,0 +1,88 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_2x2deflation
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine deflates a 2x2 block in an orthogonal 
+!  upper-hessenberg matrix
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  VEC             LOGICAL
+!                    .TRUE.: eigenvectors, assumes Z already initialized
+!                    .FALSE.: no eigenvectors
+!
+!  Q               REAL(8) array of dimension (2)
+!                    array of generators for first sequence of rotations
+!
+!  D               REAL(8) arrays of dimension (2)
+!                    array of generators for complex diagonal matrices
+!
+!  M               INTEGER
+!                    leading dimension of Z
+!
+! OUTPUT VARIABLES:
+!
+!  Z               REAL(8) array of dimension (M,2)
+!                    eigenvectors
+!                    if VEC = .TRUE. updates eigenvectors in Z 
+!                    if VEC = .FALSE. unused
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_2x2deflation(VEC,Q,D,M,Z)
+
+  implicit none
+  
+  ! input variables
+  logical, intent(in) :: VEC
+  real(8), intent(inout) :: Q(2), D(2)
+  integer, intent(in) :: M 
+  real(8), intent(inout) :: Z(M,2)
+  
+  ! compute variables
+  real(8) :: nrm, row(2), temp(2,2)
+  
+  ! D scalar
+  if (D(1).EQ.D(2)) then
+    
+    ! update Q
+    Q = sign(1d0,D(1))*Q
+
+    ! update D
+    D = 1d0
+
+  ! D not scalar
+  else
+
+    ! compute first row of Q*D
+    row(1) = Q(1)*D(1)
+    row(2) = -Q(2)*D(2)
+
+    ! update D
+    D(1) = -sign(1d0,row(1))
+    D(2) = -D(1)
+
+    ! update D
+    Q(1) = 1d0
+    Q(2) = 0d0
+
+    ! subtract off +/-1
+    row(1) = row(1) - D(1)
+
+    ! construct eliminator
+    call d_rot2_vec2gen(row(2),-row(1),temp(1,1),temp(2,1),nrm)
+     
+    ! update Z
+    if (VEC) then
+      temp(1,2) = -temp(2,1)
+      temp(2,2) = temp(1,1)
+      Z = matmul(Z,temp)
+    end if
+
+  end if
+
+end subroutine d_orthfact_2x2deflation

--- a/src/double/d_orthfact_2x2diagblock.f90
+++ b/src/double/d_orthfact_2x2diagblock.f90
@@ -1,0 +1,63 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_2x2diagblock 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine computes a two by two diagonal block of an orthogonal
+! upper hessenberg matrix that is stored as a product of givens 
+! rotations and a diagonal matrix. 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  TOP             LOGICAL
+!                    .TRUE.: top block is computed
+!                    .FALSE.: bottom block is computed
+!
+!  Q               REAL(8) array of dimension (4)
+!                    array of generators for givens rotations
+!                    generators must be orthogonal to working precision
+!
+!  D               REAL(8) array of dimension (2)
+!                    array of generators for diagonal matrix
+!                    entries must be +/-1
+!
+! OUTPUT VARIABLES:
+!
+!  H               REAL(8) array of dimension (2,2)
+!                    on exit contains the desired 2x2 block
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_2x2diagblock(TOP,Q,D,H)
+  
+  implicit none
+  
+  ! input variables
+  logical, intent(in) :: TOP
+  real(8), intent(in) :: Q(4), D(2)
+  real(8), intent(inout) :: H(2,2)
+  
+  ! TOP == .TRUE.
+  if (TOP) then
+
+    ! initialize H
+    H(1,1) = Q(1)*D(1)
+    H(2,1) = Q(2)*D(1)
+    H(1,2) = -Q(2)*Q(3)*D(2)
+    H(2,2) = Q(1)*Q(3)*D(2)
+
+  ! TOP == .FALSE.
+  else
+
+    ! initialize H
+    H(1,1) = Q(3)*Q(1)*D(1)
+    H(2,1) = Q(4)*D(1)
+    H(1,2) = -Q(4)*Q(1)*D(2)
+    H(2,2) = Q(3)*D(2)
+
+  end if 
+
+end subroutine d_orthfact_2x2diagblock

--- a/src/double/d_orthfact_2x2diagblock.f90
+++ b/src/double/d_orthfact_2x2diagblock.f90
@@ -5,9 +5,9 @@
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
-! This routine computes a two by two diagonal block of an orthogonal
-! upper hessenberg matrix that is stored as a product of givens 
-! rotations and a diagonal matrix. 
+! This routine computes either the top or bottom 2x2 diagonal block 
+! of an orthogonal upper-hessenberg matrix that is stored as a product 
+! of givens rotations and a diagonal matrix. 
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !

--- a/src/double/d_orthfact_buildbulge.f90
+++ b/src/double/d_orthfact_buildbulge.f90
@@ -1,0 +1,82 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_buildbulge
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine computes the first Givens' rotations that start a real 
+! Francis iteration. If JOB = 'S' a single Givens' rotation is 
+! constructed. If JOB = 'D' two Givens' rotations are constructed for
+! a real double shift step.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  DBL             LOGICAL
+!                    .TRUE.: real doubleshift
+!                    .FALSE.: real singleshift
+!
+!  Q               REAL(8) array of dimension (4)
+!                    array of generators for givens rotations
+!
+!  D               REAL(8) array of dimension (2)
+!                    array of generators for complex diagonal matrix
+!
+!  SHFT            REAL(8) array of dimension (2)
+!                    real and imaginary part of complex shift
+!
+! OUTPUT VARIABLES:
+!
+!  B1, B2          REAL(8) array of dimension (2)
+!                    generators for givens rotations that represent
+!                    the first transformations
+!                    if DBL == .FALSE. then B2 is unused
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_buildbulge(DBL,Q,D,SHFT,B1,B2)
+  
+  implicit none
+  
+  ! input variables
+  logical, intent(in) :: DBL
+  real(8), intent(in) :: Q(4), D(2), SHFT(2)
+  real(8), intent(inout) :: B1(2), B2(2)
+  
+  ! compute variables
+  real(8) :: nrm, COL(3), T(3,2)
+  
+  
+  ! double shift
+  if (DBL) then
+  
+    ! compute first two columns of A
+    call d_orthfact_2x2diagblock(.TRUE.,Q,D,T(1:2,1:2))  
+    T(3,1) = 0d0
+    T(3,2) = Q(4)*D(2)
+
+    ! compute p(A)e_1
+    COL(1) = T(1,1)*T(1,1) + T(1,2)*T(2,1) + SHFT(1)*SHFT(1) + SHFT(2)*SHFT(2) - 2d0*T(1,1)*SHFT(1)
+    COL(2) = T(2,1)*(T(1,1)+T(2,2)-2d0*SHFT(1))
+    COL(3) = T(2,1)*T(3,2)
+    
+    ! compute first givens rotations
+    call d_rot2_vec2gen(COL(2),COL(3),B1(1),B1(2),nrm)
+    
+    ! compute second givens rotations
+    call d_rot2_vec2gen(COL(1),nrm,B2(1),B2(2),nrm)
+    
+  ! single shift
+  else
+  
+    ! compute first block of A
+    call d_orthfact_2x2diagblock(.TRUE.,Q,D,T(1:2,1:2))  
+
+    ! compute first Givens' rotation
+    call d_rot2_vec2gen(T(1,1)-SHFT(1),T(2,1),B1(1),B1(2),nrm)
+    
+  end if
+
+end subroutine d_orthfact_buildbulge
+

--- a/src/double/d_orthfact_deflationcheck.f90
+++ b/src/double/d_orthfact_deflationcheck.f90
@@ -1,0 +1,80 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_deflationcheck
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine checks for deflations in an orthogonal upper hessenberg 
+! matrix that is stored as a product of givens rotations and a complex 
+! diagonal matrix. When a deflation occurs the corresponding rotation
+! is set to the identity matrix.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  Q               REAL(8) array of dimension (2*(N-1))
+!                    array of generators for givens rotations
+!                    generators must be orthogonal to working precision
+!
+!  D               REAL(8) array of dimension (N)
+!                    array of generators for complex diagonal matrix
+!                    entries must be +/-1
+!
+! OUTPUT VARIABLES:
+!
+!  ZERO            INTEGER
+!                     index of the last known deflation
+!                     on output contains index of newest deflation
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_deflationcheck(N,Q,D,ZERO)
+
+  implicit none
+  
+  ! input variables
+  integer, intent(in) :: N
+  real(8), intent(inout) :: Q(2*(N-1)), D(N)
+  integer, intent(inout) :: ZERO
+
+  ! compute variables
+  integer :: ii
+  real(8), parameter :: tol = EISCOR_DBL_EPS
+
+  ! initialize ZERO
+  ZERO = 0
+  
+  ! check for deflation
+  do ii=1,(N-1)
+  
+    ! deflate if subdiagonal is small enough
+    if(abs(Q(2*(N-ii))) < tol)then
+     
+      ! update D
+      D(N-ii) = sign(1d0,Q(2*(N-ii)-1)*D(N-ii))
+      D(N-ii+1) = sign(1d0,Q(2*(N-ii)-1)*D(N-ii+1))
+ 
+      ! update subsequent Q
+      if (ii > 1) then
+        Q(2*(N-ii+1)) = sign(1d0,Q(2*(N-ii)-1))*Q(2*(N-ii+1))
+      end if
+
+      ! set Q to identity
+      Q(2*(N-ii)-1) = 1d0
+      Q(2*(N-ii)) = 0d0
+       
+      ! set ZERO
+      ZERO = max(0,N-ii)
+        
+      ! exit loop  
+      exit
+
+    end if
+
+  end do
+  
+end subroutine d_orthfact_deflationcheck

--- a/src/double/d_orthfact_doublestep.f90
+++ b/src/double/d_orthfact_doublestep.f90
@@ -48,7 +48,7 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
   real(8), intent(inout) :: Q(2*(N-1)), D(N), Z(M,N)
   
   ! compute variables
-  integer :: ii, ind
+  integer :: ii, ind1, ind2
   real(8) :: s1, s2
   real(8) :: b1(2), b2(2), b3(2), temp(2), nrm
   real(8) :: block(2,2), w(2,2) 
@@ -73,7 +73,7 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     block = 0d0
     block(1,1) = s1
     block(2,2) = s2
-          
+
   ! wilkinson shifts
   else
 
@@ -84,7 +84,7 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     call d_2x2array_eig(.FALSE.,block,block,w,w)
       
   end if
-  
+
   ! two real shifts
   if (block(2,1).EQ.0d0) then
  
@@ -126,8 +126,9 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     ! main chasing loop
     do ii=1,(N-3)
        
-      ! set ind
-      ind = 2*(ii-1)
+      ! set ind2
+      ind1 = (ii-1)
+      ind2 = 2*(ii-1)
        
       ! first bulge update eigenvectors
       if (VEC)then
@@ -139,10 +140,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
       end if 
         
       ! first bulge through D
-      call d_rot2_swapdiag(D((ind+3):(ind+4)),b1)
+      call d_rot2_swapdiag(D((ind1+2):(ind1+3)),b1)
       
       ! first bulge through Q
-      call d_rot2_turnover(Q((ind+3):(ind+4)),Q((ind+5):(ind+6)),b1)
+      call d_rot2_turnover(Q((ind2+3):(ind2+4)),Q((ind2+5):(ind2+6)),b1)
       
       ! second bulge update eigenvectors
       if (VEC)then
@@ -154,15 +155,16 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
       end if 
         
       ! second bulge through D
-      call d_rot2_swapdiag(D((ind+1):(ind+2)),b2)
+      call d_rot2_swapdiag(D((ind1+1):(ind1+2)),b2)
       
       ! second bulge through Q
-      call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+      call d_rot2_turnover(Q((ind2+1):(ind2+2)),Q((ind2+3):(ind2+4)),b2)
       
     end do
     
-    ! set ind
-    ind = 2*(N-3)
+    ! set ind2
+    ind1 = (N-3)
+    ind2 = 2*(N-3)
     
     ! first bulge update eigenvectors
     if (VEC)then
@@ -174,10 +176,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     end if 
        
     ! first bulge through D
-    call d_rot2_swapdiag(D((ind+3):(ind+4)),b1)
+    call d_rot2_swapdiag(D((ind1+2):(ind1+3)),b1)
     
     ! first bulge fuse with Q
-    call d_orthfact_mergebulge(.FALSE.,Q((ind+3):(ind+4)),b1)
+    call d_orthfact_mergebulge(.FALSE.,Q((ind2+3):(ind2+4)),b1)
     
     ! second bulge update eigenvectors
     if (VEC)then
@@ -189,13 +191,14 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     end if
         
     ! second bulge through D
-    call d_rot2_swapdiag(D((ind+1):(ind+2)),b2)
+    call d_rot2_swapdiag(D((ind1+1):(ind1+2)),b2)
     
     ! second bulge through Q  
-    call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+    call d_rot2_turnover(Q((ind2+1):(ind2+2)),Q((ind2+3):(ind2+4)),b2)
     
-    ! set index
-    ind = 2*(N-2)
+    ! set ind2
+    ind1 = (N-2)
+    ind2 = 2*(N-2)
     
     ! last bulge update eigenvectors
     if (VEC)then
@@ -207,10 +210,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     end if 
   
     ! last bulge through D
-    call d_rot2_swapdiag(D((ind+1):(ind+2)),b2)
+    call d_rot2_swapdiag(D((ind1+1):(ind1+2)),b2)
     
     ! last bulge fuse with Q
-    call d_orthfact_mergebulge(.FALSE.,Q((ind+1):(ind+2)),b2)
+    call d_orthfact_mergebulge(.FALSE.,Q((ind2+1):(ind2+2)),b2)
   
   ! complex conjugate pair
   else
@@ -222,7 +225,6 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     call d_orthfact_buildbulge(.TRUE.,Q(1:4),D(1:2),temp,b1,b2)
 
     ! turnover to initialize bulge
-    ind = 2*(N-2)
     temp(1) = b2(1)
     temp(2) = -b2(2)
     b3(1) = b1(1)
@@ -241,8 +243,9 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     ! main chasing loop
     do ii=1,(N-3)
        
-      ! set ind
-      ind = 2*(ii-1)
+      ! set ind2
+      ind1 = (ii-1)
+      ind2 = 2*(ii-1)
        
       ! first bulge update eigenvectors
       if (VEC)then
@@ -254,10 +257,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
       end if 
         
       ! first bulge through D
-      call d_rot2_swapdiag(D((ind+3):(ind+4)),b1)
+      call d_rot2_swapdiag(D((ind1+2):(ind1+3)),b1)
       
       ! first bulge through Q
-      call d_rot2_turnover(Q((ind+3):(ind+4)),Q((ind+5):(ind+6)),b1)
+      call d_rot2_turnover(Q((ind2+3):(ind2+4)),Q((ind2+5):(ind2+6)),b1)
       
       ! second bulge update eigenvectors
       if (VEC)then
@@ -269,10 +272,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
       end if 
         
       ! second bulge through D
-      call d_rot2_swapdiag(D((ind+1):(ind+2)),b2)
+      call d_rot2_swapdiag(D((ind1+1):(ind1+2)),b2)
       
       ! second bulge through Q
-      call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+      call d_rot2_turnover(Q((ind2+1):(ind2+2)),Q((ind2+3):(ind2+4)),b2)
       
       ! push b3 down
       call d_rot2_turnover(b3,b1,b2)
@@ -285,8 +288,9 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
        
     end do
     
-    ! set ind
-    ind = 2*(N-3)
+    ! set ind2
+    ind1 = (N-3)
+    ind2 = 2*(N-3)
     
     ! first bulge update eigenvectors
     if (VEC)then
@@ -298,10 +302,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     end if 
        
     ! first bulge through D
-    call d_rot2_swapdiag(D((ind+3):(ind+4)),b1)
+    call d_rot2_swapdiag(D((ind1+2):(ind1+3)),b1)
     
     ! first bulge fuse with Q
-    call d_orthfact_mergebulge(.FALSE.,Q((ind+3):(ind+4)),b1)
+    call d_orthfact_mergebulge(.FALSE.,Q((ind2+3):(ind2+4)),b1)
     
     ! second bulge update eigenvectors
     if (VEC)then
@@ -313,16 +317,17 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     end if
         
     ! second bulge through D
-    call d_rot2_swapdiag(D((ind+1):(ind+2)),b2)
+    call d_rot2_swapdiag(D((ind1+1):(ind1+2)),b2)
     
     ! second bulge through Q  
-    call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+    call d_rot2_turnover(Q((ind2+1):(ind2+2)),Q((ind2+3):(ind2+4)),b2)
     
     ! fuse b2 and b3
     call d_orthfact_mergebulge(.FALSE.,b3,b2)
     
-    ! set index
-    ind = 2*(N-2)
+    ! set ind
+    ind1 = (N-2)
+    ind2 = 2*(N-2)
     
     ! last bulge update eigenvectors
     if (VEC)then
@@ -334,10 +339,10 @@ subroutine d_orthfact_doublestep(VEC,N,Q,D,M,Z,ITCNT)
     end if 
   
     ! last bulge through D
-    call d_rot2_swapdiag(D((ind+1):(ind+2)),b3)
+    call d_rot2_swapdiag(D((ind1+1):(ind1+2)),b3)
     
     ! last bulge fuse with Q
-    call d_orthfact_mergebulge(.FALSE.,Q((ind+1):(ind+2)),b3)
+    call d_orthfact_mergebulge(.FALSE.,Q((ind2+1):(ind2+2)),b3)
   
   end if ! end of doubleshift step
 

--- a/src/double/d_orthfact_doublestep.f90
+++ b/src/double/d_orthfact_doublestep.f90
@@ -1,0 +1,356 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_doublestep
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine computes one iteration of Francis' doubleshift 
+! algorithm on an orthogonal upper hessenberg matrix that is stored as a 
+! product of givens rotations and a diagonal matrix. 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  VEC             LOGICAL
+!                    .TRUE.: update eigenvectors
+!                    .FALSE.: no eigenvectors
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  Q               REAL(8) array of dimension (2*(N-1))
+!                    array of generators for givens rotations
+!
+!  D               REAL(8) array of dimension (N)
+!                    array of generators for complex diagonal matrix
+!
+!  M               INTEGER
+!                    leading dimension of Z
+!
+!  Z               REAL(8) array of dimension (M,N)
+!                    if VEC = .TRUE. updated
+!                    if VEC = .FALSE. unused
+!
+!  ITCNT           INTEGER
+!                   Contains the number of iterations since last deflation
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_doublestep(STR,STP,VEC,N,Q,D,M,Z,ITCNT)
+
+  implicit none
+  
+  ! input variables
+  logical, intent(in) :: VEC
+  integer, intent(in) :: N, M
+  integer, intent(in) :: STR, STP
+  integer, intent(inout) :: ITCNT
+  real(8), intent(inout) :: Q(2*(N-1)), D(N), Z(M,N)
+  
+  ! compute variables
+  integer :: ii, ind
+  real(8) :: s1, s2
+  real(8) :: b1(2), b2(2), b3(2), temp(2), nrm
+  real(8) :: block(2,2) 
+  complex(8) :: eigs(2), h(2,2)
+
+  ! compute a nonzero shift
+  ! shifts +1
+  if((mod(ITCNT+1,11) == 0).AND.(ITCNT.NE.0))then
+    eigs(1) = cmplx(1d0,0d0,kind=8)
+    eigs(2) = cmplx(1d0,0d0,kind=8)
+    
+  ! shifts -1
+  else if((mod(ITCNT+1,16) == 0).AND.(ITCNT.NE.0))then
+    eigs(1) = cmplx(-1d0,0d0,kind=8)
+    eigs(2) = cmplx(-1d0,0d0,kind=8)
+    
+  ! random shift
+  else if((mod(ITCNT+1,21) == 0).AND.(ITCNT.NE.0))then
+    call random_number(s1)
+    call random_number(s2)
+    eigs(1) = cmplx(s1,s2,kind=8)
+    eigs(2) = cmplx(s1,-s2,kind=8)
+          
+  ! wilkinson shifts
+  else
+
+    ! get 2x2 block
+    call d_orthfact_2x2diagblock(.FALSE.,Q((2*N-5):(2*N-2)),D((N-1):N),block)
+      
+    ! compute eigenvalues and eigenvectors
+    call d_2x2array_eig(block,eigs,h)
+      
+  end if
+  
+  ! two real shifts
+  if ((aimag(eigs(1)).EQ.0d0).AND.(aimag(eigs(2)).EQ.0d0)) then
+ 
+    ! first shift
+    eigs(1) = cmplx(sign(1d0,dble(eigs(1))),0d0,kind=8)
+    
+    ! build first bulge
+    temp(1) = dble(eigs(1))
+    temp(2) = aimag(eigs(1))
+    call d_orthfact_buildbulge('S',N,STR,Q,D,temp,b1,b2)
+
+    ! fusion to initialize first bulge
+    ind = 2*(STR-1)
+    b3(1) = b1(1)
+    b3(2) = -b1(2)
+    call d_orthfact_mergebulge('R',b3,Q((ind+1):(ind+2)))
+     
+    ! first bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b1(1)
+      h(2,1) = b1(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,STR:(STR+1)) = matmul(Z(:,STR:(STR+1)),h)
+    end if 
+    
+    ! first bulge through D
+    call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b1)
+      
+    ! first bulge through Q
+    call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b1)
+      
+    ! second shift
+    eigs(2) = cmplx(sign(1d0,dble(eigs(2))),0d0,kind=8)
+  
+    ! build bulge
+    temp(1) = dble(eigs(2))
+    temp(2) = aimag(eigs(2))
+    call d_orthfact_buildbulge('S',N,STR,Q,D,temp,b2,b3)
+          
+    ! fusion to initialize second bulge
+    b3(1) = b2(1)
+    b3(2) = -b2(2)
+    call d_orthfact_mergebulge('R',b3,Q((ind+1):(ind+2)))
+     
+    ! main chasing loop
+    do ii=STR,(STP-2)
+       
+      ! set ind
+      ind = 2*(ii-1)
+       
+      ! first bulge update eigenvectors
+      if (VEC)then
+        h(1,1) = b1(1)
+        h(2,1) = b1(2)
+        h(1,2) = -h(2,1)
+        h(2,2) = h(1,1)
+        Z(:,(ii+1):(ii+2)) = matmul(Z(:,(ii+1):(ii+2)),h)
+      end if 
+        
+      ! first bulge through D
+      call d_rot2_swapdiag('R',D((ind+3):(ind+6)),b1)
+      
+      ! first bulge through Q
+      call d_rot2_turnover(Q((ind+3):(ind+4)),Q((ind+5):(ind+6)),b1)
+      
+      ! second bulge update eigenvectors
+      if (VEC)then
+        h(1,1) = b2(1)
+        h(2,1) = b2(2)
+        h(1,2) = -h(2,1)
+        h(2,2) = h(1,1)
+        Z(:,ii:(ii+1)) = matmul(Z(:,ii:(ii+1)),h)
+      end if 
+        
+      ! second bulge through D
+      call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b2)
+      
+      ! second bulge through Q
+      call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+      
+    end do
+    
+    ! set ind
+    ind = 2*(stp-2)
+    
+    ! first bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b1(1)
+      h(2,1) = b1(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,STP:(STP+1)) = matmul(Z(:,STP:(STP+1)),h)
+    end if 
+       
+    ! first bulge through D
+    call d_rot2_swapdiag('R',D((ind+3):(ind+6)),b1)
+    
+    ! first bulge fuse with Q
+    call d_orthfact_mergebulge('L',Q((ind+3):(ind+4)),b1)
+    
+    ! second bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b2(1)
+      h(2,1) = b2(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,(STP-1):STP) = matmul(Z(:,(STP-1):STP),h)
+    end if
+        
+    ! second bulge through D
+    call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b2)
+    
+    ! second bulge through Q  
+    call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+    
+    ! set index
+    ind = 2*(stp-1)
+    
+    ! last bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b2(1)
+      h(2,1) = b2(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,STP:(STP+1)) = matmul(Z(:,STP:(STP+1)),h)
+    end if 
+  
+    ! last bulge through D
+    call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b2)
+    
+    ! last bulge fuse with Q
+    call d_orthfact_mergebulge('L',Q((ind+1):(ind+2)),b2)
+  
+    ! update ITCNT
+    ITCNT = ITCNT + 1
+
+  ! complex conjugate pair
+  else
+  
+    ! normalize shifts
+    call d_rot2_vec2gen(dble(eigs(1)),aimag(eigs(1)),temp(1),temp(2),nrm) 
+
+    ! build bulge
+    call d_orthfact_buildbulge('D',N,STR,Q,D,temp,b1,b2)
+
+    ! turnover to initialize bulge
+    ind = 2*(STR-1)
+    temp(1) = b2(1)
+    temp(2) = -b2(2)
+    b3(1) = b1(1)
+    b3(2) = -b1(2)
+    call d_rot2_turnover(temp,b3,Q((ind+1):(ind+2)))
+      
+    ! fusion to finish initialization
+    call d_orthfact_mergebulge('R',b3,Q((ind+3):(ind+4)))
+     
+    ! update b3
+    b3 = Q((ind+1):(ind+2))
+    
+    ! update Q
+    Q((ind+1):(ind+2)) = temp
+    
+    ! main chasing loop
+    do ii=str,(stp-2)
+       
+      ! set ind
+      ind = 2*(ii-1)
+       
+      ! first bulge update eigenvectors
+      if (VEC)then
+        h(1,1) = b1(1)
+        h(2,1) = b1(2)
+        h(1,2) = -h(2,1)
+        h(2,2) = h(1,1)
+        Z(:,(ii+1):(ii+2)) = matmul(Z(:,(ii+1):(ii+2)),h)
+      end if 
+        
+      ! first bulge through D
+      call d_rot2_swapdiag('R',D((ind+3):(ind+6)),b1)
+      
+      ! first bulge through Q
+      call d_rot2_turnover(Q((ind+3):(ind+4)),Q((ind+5):(ind+6)),b1)
+      
+      ! second bulge update eigenvectors
+      if (VEC)then
+        h(1,1) = b2(1)
+        h(2,1) = b2(2)
+        h(1,2) = -h(2,1)
+        h(2,2) = h(1,1)
+        Z(:,ii:(ii+1)) = matmul(Z(:,ii:(ii+1)),h)
+      end if 
+        
+      ! second bulge through D
+      call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b2)
+      
+      ! second bulge through Q
+      call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+      
+      ! push b3 down
+      call d_rot2_turnover(b3,b1,b2)
+      
+    ! update bulges
+      temp = b2
+      b2 = b3
+      b3 = b1
+      b1 = temp
+       
+    end do
+    
+    ! set ind
+    ind = 2*(stp-2)
+    
+    ! first bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b1(1)
+      h(2,1) = b1(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,STP:(STP+1)) = matmul(Z(:,STP:(STP+1)),h)
+    end if 
+       
+    ! first bulge through D
+    call d_rot2_swapdiag('R',D((ind+3):(ind+6)),b1)
+    
+    ! first bulge fuse with Q
+    call d_orthfact_mergebulge('L',Q((ind+3):(ind+4)),b1)
+    
+    ! second bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b2(1)
+      h(2,1) = b2(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,(STP-1):STP) = matmul(Z(:,(STP-1):STP),h)
+    end if
+        
+    ! second bulge through D
+    call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b2)
+    
+    ! second bulge through Q  
+    call d_rot2_turnover(Q((ind+1):(ind+2)),Q((ind+3):(ind+4)),b2)
+    
+    ! fuse b2 and b3
+    call d_orthfact_mergebulge('L',b3,b2)
+    
+    ! set index
+    ind = 2*(stp-1)
+    
+    ! last bulge update eigenvectors
+    if (VEC)then
+      h(1,1) = b3(1)
+      h(2,1) = b3(2)
+      h(1,2) = -h(2,1)
+      h(2,2) = h(1,1)
+      Z(:,STP:(STP+1)) = matmul(Z(:,STP:(STP+1)),h)
+    end if 
+  
+    ! last bulge through D
+    call d_rot2_swapdiag('R',D((ind+1):(ind+4)),b3)
+    
+    ! last bulge fuse with Q
+    call d_orthfact_mergebulge('L',Q((ind+1):(ind+2)),b3)
+  
+    ! update ITCNT
+    ITCNT = ITCNT + 1
+  
+  end if ! end of doubleshift step
+
+end subroutine d_orthfact_doublestep

--- a/src/double/d_orthfact_factorcheck.f90
+++ b/src/double/d_orthfact_factorcheck.f90
@@ -1,0 +1,84 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_factorcheck
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine checks the factorization input into d_orthfact_qr to make sure
+! is represents a unitary hessenberg matrix to machine precision. 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  Q               REAL(8) array of dimension (2*(N-1))
+!                    array of generators for givens rotations
+!
+!  D               REAL(8) array of dimension (N)
+!                    array of generators for complex diagonal matrix
+!                    on output contains the eigenvalues
+!
+! OUTPUT VARIABLES:
+!
+!  INFO           INTEGER
+!                    INFO = 0 implies valid factorization
+!                    INFO = -1 implies N is invalid
+!                    INFO = -2 implies Q is invalid
+!                    INFO = -3 implies D is invalid
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_factorcheck(N,Q,D,INFO)
+
+  implicit none
+  
+  ! input variables
+  integer, intent(in) :: N
+  real(8), intent(inout) :: Q(2*(N-1)), D(N)
+  integer, intent(inout) :: INFO
+  
+  ! compute variables
+  logical :: flg
+  integer :: ii
+  real(8), parameter :: tol = 1d1*EISCOR_DBL_EPS
+  
+  ! initialize INFO
+  INFO = 0
+  
+  ! check N
+  if (N < 2) then
+    INFO = -1
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"N must be at least 2",INFO,INFO)
+    end if
+    return
+  end if
+  
+  ! check Q 
+  call d_rot2array_check(N-1,Q,flg)
+  if (.NOT.flg) then
+    INFO = -2
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"Q is invalid",INFO,INFO)
+    end if
+    return
+  end if
+  
+  ! check D 
+  do ii=1,N
+    if (abs(D(ii)).NE.1d0) then
+      INFO = -3
+      ! print error in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"D is invalid",INFO,INFO)
+      end if
+      return
+    end if
+  end do
+  
+end subroutine d_orthfact_factorcheck

--- a/src/double/d_orthfact_mergebulge.f90
+++ b/src/double/d_orthfact_mergebulge.f90
@@ -1,0 +1,59 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_mergebulge
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine computes the product of two real Given's rotations and 
+! and stores the output in one of the input arrays.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  TOP             LOGICAL
+!                    .TRUE.: merge bulge at top
+!                    .FALSE.: merge bulge at bottom
+!
+!  Q               REAL(8) array of dimension (2)
+!                    generator unitary matrix
+!
+!  B               REAL(8) array of dimension (2)
+!                    generator for bulge
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_mergebulge(TOP,Q,B)
+
+  implicit none
+
+  ! input variables
+  logical, intent(in) :: TOP
+  real(8), intent(inout) :: Q(2), B(2)
+
+  ! compute variables
+  real(8) :: c, s, nrm
+
+  ! merge at top
+  if(TOP)then
+
+    ! compute new generators
+    c = B(1)*Q(1)-B(2)*Q(2)
+    s = B(2)*Q(1)+B(1)*Q(2)
+    
+    ! compute new generators
+    call d_rot2_vec2gen(c,s,Q(1),Q(2),nrm)
+    
+  ! merge at bottom
+  else
+
+    ! compute new generators
+    c = Q(1)*B(1)-Q(2)*B(2)
+    s = Q(2)*B(1)+Q(1)*B(2)
+    
+    ! compute new generators
+    call d_rot2_vec2gen(c,s,Q(1),Q(2),nrm)
+    
+  end if
+
+end subroutine d_orthfact_mergebulge

--- a/src/double/d_orthfact_qr.f90
+++ b/src/double/d_orthfact_qr.f90
@@ -64,17 +64,47 @@ subroutine d_orthfact_qr(VEC,ID,N,Q,D,M,Z,ITS,INFO)
   real(8), intent(inout) :: Q(2*(N-1)), D(N), Z(M,N)
   
   ! compute variables
+  logical :: flg
   integer :: ii, jj, kk, ind
   integer :: STR, STP, ZERO, ITMAX, ITCNT
   real(8) :: block(2,2) 
-  complex(8) :: temp(2,2), eigs(2)
 
   ! initialize INFO
   INFO = 0
   
   ! check factorization
+  call d_orthfact_factorcheck(N,Q,D,INFO)
+  if (INFO.NE.0) then
+    INFO = INFO - 2
+    ! print error message in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"N, Q, or D is invalid",INFO,INFO)
+    end if
+    return
+  end if
+  
+  ! check M
+  if (VEC.AND.(M < 1)) then
+    INFO = -6
+    ! print error message in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"M must be at least 1",INFO,INFO)
+    end if
+    return
+  end if
   
   ! check Z
+  if (VEC.AND..NOT.ID) then
+    call d_2Darray_check(M,N,Z,flg)
+    if (.NOT.flg) then
+      INFO = -7
+      ! print error message in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"Z is invalid",INFO,INFO)
+      end if
+      return
+    end if
+  end if   
   
   ! initialize storage
   ITS = 0
@@ -100,7 +130,7 @@ subroutine d_orthfact_qr(VEC,ID,N,Q,D,M,Z,ITS,INFO)
     if(STP <= 0)then
       exit
     end if
-        
+
     ! check for deflation
     call d_orthfact_deflationcheck(STP-STR+2,Q((2*STR-1):(2*STP)),D(STR:(STP+1)),ZERO)
 

--- a/src/double/d_orthfact_qr.f90
+++ b/src/double/d_orthfact_qr.f90
@@ -1,0 +1,155 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthfact_qr
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine computes the eigenvalues and optionally eigen(Schur)vectors of 
+! an orthogonal upper hessenberg matrix that is stored as a product of 
+! givens rotations and a diagonal matrix.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  VEC             LOGICAL
+!                    .TRUE.: compute eigenvectors
+!                    .FALSE.: no eigenvectors
+!
+!  ID              LOGICAL
+!                    .TRUE.: initialize to Z to identity
+!                    .FALSE.: assume Z is already initialized
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  Q               REAL(8) array of dimension (2*(N-1))
+!                    array of generators for givens rotations
+!
+!  D               REAL(8) array of dimension (N)
+!                    array of generators for complex diagonal matrix
+!
+!  M               INTEGER
+!                    leading dimension of Z
+!
+! OUTPUT VARIABLES:
+!
+!  Z               REAL(8) array of dimension (M,N)
+!                    if VEC = .FALSE. unused
+!                    if VEC = .TRUE. and ID = .TRUE. initializes Z to I 
+!                    if VEC = .TRUE. and ID = .FALSE. assumes Z initialized
+!
+!  ITS             INTEGER array of dimension (N-1)
+!                    Contains the number of iterations per deflation
+!
+!  INFO            INTEGER
+!                    INFO = 1 implies no convergence
+!                    INFO = 0 implies successful computation
+!                    INFO = -3 implies N is invalid
+!                    INFO = -4 implies Q is invalid
+!                    INFO = -5 implies D is invalid
+!                    INFO = -6 implies M is invalid
+!                    INFO = -7 implies Z is invalid
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthfact_qr(VEC,ID,N,Q,D,M,Z,ITS,INFO)
+  
+  implicit none
+  
+  ! input variables
+  logical, intent(in) :: VEC, ID
+  integer, intent(in) :: N, M
+  integer, intent(inout) :: INFO, ITS(N-1)
+  real(8), intent(inout) :: Q(2*(N-1)), D(N), Z(M,N)
+  
+  ! compute variables
+  integer :: ii, jj, kk, ind
+  integer :: STR, STP, ZERO, ITMAX, ITCNT
+  real(8) :: block(2,2) 
+  complex(8) :: temp(2,2), eigs(2)
+
+  ! initialize INFO
+  INFO = 0
+  
+  ! check factorization
+  
+  ! check Z
+  
+  ! initialize storage
+  ITS = 0
+    
+  if (VEC.AND.ID) then
+    Z = 0d0
+    do ii=1,min(M,N)
+      Z(ii,ii) = 1d0
+    end do
+  end if
+  
+  ! initialize indices
+  STR = 1
+  STP = N-1
+  ZERO = 0
+  ITMAX = 20*N
+  ITCNT = 0
+
+  ! loop for bulgechasing
+  do kk=1,ITMAX
+
+    ! check for completion
+    if(STP <= 0)then
+      exit
+    end if
+        
+    ! check for deflation
+    call d_orthfact_deflationcheck(STP-STR+2,Q((2*STR-1):(2*STP)),D(STR:(STP+1)),ZERO)
+
+    ! if 1x1 block remove and check again 
+    if(STP == (STR+ZERO-1))then
+    
+      ! update indices
+      ITS(STR+STP-1) = ITCNT
+      ITCNT = 0
+      STP = STP - 1
+      ZERO = 0
+      STR = 1
+           
+    ! if 2x2 block remove and check again
+    else if(STP == (STR+ZERO))then
+    
+      ! call 2x2 deflation
+      call d_orthfact_2x2deflation(VEC,Q((2*STP-1):(2*STP)),D(STP:(STP+1)),M,Z(:,STP:(STP+1)))
+    
+      ! update indices
+      ITS(STR+STP-1) = ITCNT
+      ITCNT = 0
+      STP = STP - 2
+      ZERO = 0
+      STR = 1
+        
+    ! if greater than 2x2 chase a bulge
+    else
+
+      ! check STR
+      if (STR <= ZERO) then
+        STR = ZERO+1
+      end if
+
+      ! perform singleshift iteration
+      call d_orthfact_doublestep(VEC,STP-STR+2,Q((2*STR-1):(2*STP)),D(STR:(STP+1)) &
+      ,M,Z(:,STR:(STP+1)),ITCNT)
+     
+      ! update indices
+      ITCNT = ITCNT + 1
+ 
+    end if
+    
+    ! if ITMAX hit
+    if (kk == ITMAX) then
+      INFO = 1
+      ITS(STR+STP-1) = ITCNT
+    end if
+    
+  end do 
+  
+end subroutine d_orthfact_qr

--- a/src/double/d_orthhess_factor.f90
+++ b/src/double/d_orthhess_factor.f90
@@ -1,0 +1,120 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthhess_factor
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine factors a real orthogonal upper hessenberg matrix into
+! a sequence of Givens' rotations and a diagonal matrix. 
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  H               REAL(8) array of dimension (N,N)
+!                    unitary matrix to be reduced
+!
+!  Q               REAL(8) array of dimension (2*(N-1))
+!                    array of generators for Givens' rotations
+!
+!  D               REAL(8) array of dimension (N)
+!                    array of generators for diagonal matrix
+!
+! OUTPUT VARIABLES:
+!
+!  INFO            INTEGER
+!                    INFO = 0 implies successful computation
+!                    INFO = -1 implies N is invalid
+!                    INFO = -2 implies H is invalid
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthhess_factor(N,H,Q,D,INFO)
+
+  implicit none
+  
+  ! input variables
+  integer, intent(in) :: N
+  real(8), intent(inout) :: H(N,N), Q(2*(N-1)), D(2*N)
+  integer, intent(inout) :: INFO
+  
+  ! compute variables
+  logical :: flg
+  integer :: ii, ind
+  real(8) :: nrm, tol 
+  real(8) :: c, s
+  
+  ! initialize info
+  INFO = 0
+  
+  ! check N
+  if (N < 2) then
+    INFO = -1
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"N must be at least 2",INFO,INFO)
+    end if
+    return
+  end if
+  
+  ! check H
+  call d_2Darray_check(N,N,H,flg)
+  if (.NOT.flg) then
+    INFO = -2
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"H is invalid",INFO,INFO)
+    end if
+    return
+  end if  
+  
+  ! set tol
+  tol = max(10d0,dble(N))*EISCOR_DBL_EPS
+  
+  ! loop for reduction
+  ! ii is the column being reduced
+  do ii=1,(N-1)
+            
+    ! reduce to block diagonal
+    call d_rot2_vec2gen(H(ii,ii),H(ii+1,ii),c,s,nrm)
+    
+    ! check for unitarity       
+    if (abs(abs(nrm)-1d0) >= tol) then
+      INFO = -3
+      ! print error in debug mode
+      if (DEBUG) then
+        call u_infocode_check(__FILE__,__LINE__,"H is not orthogonal",INFO,INFO)
+      end if  
+      return          
+    end if
+    
+    ! update H
+    H(ii,ii) = c*H(ii,ii) + s*H(ii+1,ii)
+    H(ii+1,(ii+1):N) = -s*H(ii,(ii+1):N) + c*H(ii+1,(ii+1):N)
+         
+    ! store in Q
+    Q(2*(ii-1)+1) = c
+    Q(2*(ii-1)+2) = s
+          
+    ! store in D
+    D(ii) = sign(1d0,H(ii,ii))
+   
+  end do
+  
+  ! check for unitarity       
+  if (abs(abs(H(N,N))-1d0) >= tol) then
+    INFO = -3
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"H is not orthogonal",INFO,INFO)
+    end if  
+    return        
+  end if
+          
+  ! store in D
+  D(N) = sign(1d0,H(N,N))
+
+end subroutine d_orthhess_factor

--- a/src/double/d_orthhess_factor.f90
+++ b/src/double/d_orthhess_factor.f90
@@ -38,7 +38,7 @@ subroutine d_orthhess_factor(N,H,Q,D,INFO)
   
   ! input variables
   integer, intent(in) :: N
-  real(8), intent(inout) :: H(N,N), Q(2*(N-1)), D(2*N)
+  real(8), intent(inout) :: H(N,N), Q(2*(N-1)), D(N)
   integer, intent(inout) :: INFO
   
   ! compute variables
@@ -103,7 +103,7 @@ subroutine d_orthhess_factor(N,H,Q,D,INFO)
     D(ii) = sign(1d0,H(ii,ii))
    
   end do
-  
+
   ! check for unitarity       
   if (abs(abs(H(N,N))-1d0) >= tol) then
     INFO = -3

--- a/src/double/d_orthhess_qr.f90
+++ b/src/double/d_orthhess_qr.f90
@@ -1,0 +1,115 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_orthhess_qr
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine computes the eigenvalues and optionally eigenvectors
+! of a real orthogonal upper hessenberg matrix.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  VEC             LOGICAL
+!                    .TRUE.: compute eigenvectors
+!                    .FALSE.: no eigenvectors
+!
+!  ID              LOGICAL
+!                    .TRUE.: initialize to Z to identity
+!                    .FALSE.: assume Z is already initialized
+!
+!  N               INTEGER
+!                    dimension of matrix
+!
+!  H               REAL(8) array of dimension (N,N)
+!                    orthogonal hessenberg matrix, assumed that H(ii,jj) = 0 for |ii-jj| > 0
+!                    on exit contains a diagonal matrix whose entries are the 
+!                    eigenvalues of H
+!
+!  WORK            REAL(8) array of dimension (3*N)
+!                    work space for eigensolver
+!
+!  M               INTEGER
+!                    leading dimension of Z
+!
+! OUTPUT VARIABLES:
+!
+!  Z               REAL(8) array of dimension (M,N)
+!                    if VEC = .FALSE. unused
+!                    if VEC = .TRUE. and ID = .TRUE. initializes Z to I 
+!                    if VEC = .TRUE. and ID = .FALSE. assumes Z initialized
+!
+!  ITS             INTEGER array of dimension (N-1)
+!                    Contains the number of iterations per deflation
+!
+!  INFO            INTEGER
+!                    INFO = 2 implies d_orthfact_qr failed
+!                    INFO = 1 implies d_orthhess_factor failed
+!                    INFO = 0 implies successful computation
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_orthhess_qr(VEC,ID,N,H,WORK,M,Z,ITS,INFO)
+
+  implicit none
+  
+  ! input variables
+  logical, intent(in) :: VEC, ID
+  integer, intent(in) :: N, M
+  real(8), intent(inout) :: WORK(3*N)
+  integer, intent(inout) :: ITS(N-1), INFO
+  real(8), intent(inout) :: H(N,N), Z(M,N)
+  
+  ! compute variables
+  logical :: flg
+  integer :: ii,cpair
+  real(8) :: c,s
+  
+  ! initialize INFO
+  INFO = 0
+  
+  ! compress H
+  call d_orthhess_factor(N,H,WORK(1:(2*N)),WORK((2*N+1):(3*N)),INFO)
+
+  ! check info
+  if (INFO.NE.0) then 
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"d_orthhess_factor failed",INFO,INFO)
+    end if 
+    INFO = 1
+    return
+  end if
+  
+  ! compute eigenvalues
+  call d_orthfact_qr(VEC,ID,N,WORK(1:(2*N)),WORK((2*N+1):(3*N)),M,Z,ITS,INFO) 
+
+  ! check info
+  if (INFO.NE.0) then 
+    ! print error in debug mode
+    if (DEBUG) then
+      call u_infocode_check(__FILE__,__LINE__,"d_orthfact_qr failed",INFO,INFO)
+    end if
+    INFO = 2 
+    return
+  end if
+  
+  ! update H
+  H = 0d0
+  do ii=1,N
+    H(ii,ii) = 1d0
+  end do
+  do ii=1,N-1
+    if (abs(WORK(2*ii)).NE.0d0) then 
+       H(ii,ii) = WORK(2*ii-1)
+       H(ii+1,ii+1) = WORK(2*ii-1)
+       H(ii+1,ii) = WORK(2*ii)
+       H(ii,ii+1) = -WORK(2*ii)
+    end if
+  end do
+  do ii=1,N
+    H(:,ii) = H(:,ii)*WORK(2*N+ii)
+  end do
+  
+end subroutine d_orthhess_qr

--- a/src/double/d_rot2_swapdiag.f90
+++ b/src/double/d_rot2_swapdiag.f90
@@ -29,11 +29,8 @@ subroutine d_rot2_swapdiag(D,B)
   real(8), intent(in) :: D(2)
   real(8), intent(inout) :: B(2)
   
-  ! return if scalar
-  if (D(1).EQ.D(2)) then
-    return
-  ! change sign
-  else
+  ! change sign in D not scalar
+  if (D(1).NE.D(2)) then
     B(2) = -B(2)
   end if 
   

--- a/src/double/d_rot2_swapdiag.f90
+++ b/src/double/d_rot2_swapdiag.f90
@@ -1,0 +1,40 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_rot2_swapdiag
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine passes the generator for a Givens rotation represented
+! by 2 real numbers: a strictly real cosine and a scrictly real sine 
+! through a 2x2 diagonal matrix with entries +/-1.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  D               REAL(8) array of dimension (2)
+!                    array of generators for complex diagonal matrix
+!                    the entries of D must be +/-1
+!
+!  B               REAL(8) array of dimension (2)
+!                    generator for a Givens rotation
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_rot2_swapdiag(D,B)
+
+  implicit none
+  
+  ! input variables
+  real(8), intent(in) :: D(2)
+  real(8), intent(inout) :: B(2)
+  
+  ! return if scalar
+  if (D(1).EQ.D(2)) then
+    return
+  ! change sign
+  else
+    B(2) = -B(2)
+  end if 
+  
+end subroutine d_rot2_swapdiag

--- a/src/double/d_rot2_turnover.f90
+++ b/src/double/d_rot2_turnover.f90
@@ -16,25 +16,16 @@
 !  Q1, Q2, Q3       REAL(8) arrays of dimension (2)
 !                    generators for givens rotations
 !
-! OUTPUT VARIABLES:
-!
-!  INFO            INTEGER
-!                    INFO = 0 implies successful computation
-!                    INFO = -1 implies Q1 is invalid
-!                    INFO = -2 implies Q2 is invalid
-!                    INFO = -3 implies Q3 is invalid
-!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-subroutine d_rot2_turnover(Q1,Q2,Q3,INFO)
+subroutine d_rot2_turnover(Q1,Q2,Q3)
 
   implicit none
   
   ! input variables
-  integer, intent(inout) :: INFO
   real(8), intent(inout) :: Q1(2), Q2(2), Q3(2)
 
   ! compute variables
-  real(8), parameter :: tol = epsilon(1d0)
+  real(8), parameter :: tol = EISCOR_DBL_EPS
   real(8) :: nrm
   real(8) :: a, b 
   real(8) :: c1, s1
@@ -44,35 +35,6 @@ subroutine d_rot2_turnover(Q1,Q2,Q3,INFO)
   real(8) :: c5, s5
   real(8) :: c6, s6
   
-  ! initialize INFO
-  INFO = 0
-  
-  ! check input in debug mode
-  if (DEBUG) then
-  
-    ! check Q1
-    call d_1Darray_check(2,Q1,INFO)
-    call u_infocode_check(__FILE__,__LINE__,"Q1 is invalid",INFO,-1)
-    if (INFO.NE.0) then 
-      return 
-    end if 
-    
-    ! check Q2
-    call d_1Darray_check(2,Q2,INFO)
-    call u_infocode_check(__FILE__,__LINE__,"Q2 is invalid",INFO,-2)
-    if (INFO.NE.0) then 
-      return 
-    end if   
-    
-    ! check Q3
-    call d_1Darray_check(2,Q3,INFO)
-    call u_infocode_check(__FILE__,__LINE__,"Q3 is invalid",INFO,-3)
-    if (INFO.NE.0) then 
-      return 
-    end if  
-  
-  end if
-
   ! set local variables
   c1 = Q1(1)
   s1 = Q1(2)
@@ -86,45 +48,21 @@ subroutine d_rot2_turnover(Q1,Q2,Q3,INFO)
   b = s2*s3
   
   ! compute first rotation
-  call d_rot2_vec2gen(a,b,c4,s4,nrm,INFO)
-
-  ! check INFO in debug mode
-  if (DEBUG) then
-    call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
-    if (INFO.NE.0) then 
-      return 
-    end if 
-  end if
+  call d_rot2_vec2gen(a,b,c4,s4,nrm)
 
   ! initialize c5 and s5
   a = c1*c3 - s1*c2*s3
   b = nrm
 
   ! compute second rotation
-  call d_rot2_vec2gen(a,b,c5,s5,nrm,INFO)
-
-  ! check INFO in debug mode
-  if (DEBUG) then
-    call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
-    if (INFO.NE.0) then 
-      return 
-    end if 
-  end if
+  call d_rot2_vec2gen(a,b,c5,s5,nrm)
 
   ! second column
   a = -(-c1*s3-s1*c2*c3)*s5 + ((-s1*s3+c1*c2*c3)*c4 + s2*c3*s4)*c5
   b = -(-s1*s3+c1*c2*c3)*s4 + s2*c3*c4
   
   ! compute first rotation
-  call d_rot2_vec2gen(a,b,c6,s6,nrm,INFO)
-
-  ! check INFO in debug mode
-  if (DEBUG) then
-    call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
-    if (INFO.NE.0) then 
-      return 
-    end if 
-  end if
+  call d_rot2_vec2gen(a,b,c6,s6,nrm)
 
   ! set output
   Q1(1) = c5

--- a/src/double/d_rot2_turnover.f90
+++ b/src/double/d_rot2_turnover.f90
@@ -1,0 +1,137 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_rot2_turnover
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This routine uses the generators for three Givens rotations represented
+! by 3 real numbers: the real and imaginary parts of a complex cosine
+! and a scrictly real sine and performs a turnover.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES:
+!
+!  Q1, Q2, Q3       REAL(8) arrays of dimension (2)
+!                    generators for givens rotations
+!
+! OUTPUT VARIABLES:
+!
+!  INFO            INTEGER
+!                    INFO = 0 implies successful computation
+!                    INFO = -1 implies Q1 is invalid
+!                    INFO = -2 implies Q2 is invalid
+!                    INFO = -3 implies Q3 is invalid
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_rot2_turnover(Q1,Q2,Q3,INFO)
+
+  implicit none
+  
+  ! input variables
+  integer, intent(inout) :: INFO
+  real(8), intent(inout) :: Q1(2), Q2(2), Q3(2)
+
+  ! compute variables
+  real(8), parameter :: tol = epsilon(1d0)
+  real(8) :: nrm
+  real(8) :: a, b 
+  real(8) :: c1, s1
+  real(8) :: c2, s2
+  real(8) :: c3, s3
+  real(8) :: c4, s4
+  real(8) :: c5, s5
+  real(8) :: c6, s6
+  
+  ! initialize INFO
+  INFO = 0
+  
+  ! check input in debug mode
+  if (DEBUG) then
+  
+    ! check Q1
+    call d_1Darray_check(2,Q1,INFO)
+    call u_infocode_check(__FILE__,__LINE__,"Q1 is invalid",INFO,-1)
+    if (INFO.NE.0) then 
+      return 
+    end if 
+    
+    ! check Q2
+    call d_1Darray_check(2,Q2,INFO)
+    call u_infocode_check(__FILE__,__LINE__,"Q2 is invalid",INFO,-2)
+    if (INFO.NE.0) then 
+      return 
+    end if   
+    
+    ! check Q3
+    call d_1Darray_check(2,Q3,INFO)
+    call u_infocode_check(__FILE__,__LINE__,"Q3 is invalid",INFO,-3)
+    if (INFO.NE.0) then 
+      return 
+    end if  
+  
+  end if
+
+  ! set local variables
+  c1 = Q1(1)
+  s1 = Q1(2)
+  c2 = Q2(1)
+  s2 = Q2(2)
+  c3 = Q3(1)
+  s3 = Q3(2)
+  
+  ! initialize c4 and s4
+  a = s1*c3 + c1*c2*s3
+  b = s2*s3
+  
+  ! compute first rotation
+  call d_rot2_vec2gen(a,b,c4,s4,nrm,INFO)
+
+  ! check INFO in debug mode
+  if (DEBUG) then
+    call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+    if (INFO.NE.0) then 
+      return 
+    end if 
+  end if
+
+  ! initialize c5 and s5
+  a = c1*c3 - s1*c2*s3
+  b = nrm
+
+  ! compute second rotation
+  call d_rot2_vec2gen(a,b,c5,s5,nrm,INFO)
+
+  ! check INFO in debug mode
+  if (DEBUG) then
+    call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+    if (INFO.NE.0) then 
+      return 
+    end if 
+  end if
+
+  ! second column
+  a = -(-c1*s3-s1*c2*c3)*s5 + ((-s1*s3+c1*c2*c3)*c4 + s2*c3*s4)*c5
+  b = -(-s1*s3+c1*c2*c3)*s4 + s2*c3*c4
+  
+  ! compute first rotation
+  call d_rot2_vec2gen(a,b,c6,s6,nrm,INFO)
+
+  ! check INFO in debug mode
+  if (DEBUG) then
+    call u_infocode_check(__FILE__,__LINE__,"d_rot2_vec2gen failed",INFO,INFO)
+    if (INFO.NE.0) then 
+      return 
+    end if 
+  end if
+
+  ! set output
+  Q1(1) = c5
+  Q1(2) = s5
+  Q2(1) = c6
+  Q2(2) = s6
+  Q3(1) = c4
+  Q3(2) = s4
+       
+end subroutine d_rot2_turnover

--- a/test/double/test_d_2x2array_eig.f90
+++ b/test/double/test_d_2x2array_eig.f90
@@ -10,7 +10,9 @@
 !
 ! 1) A = [1,2;2,1], B = I
 !
-! 2) A = [0.5, 0.3; 0.2, 0.3], B = I
+! 2) A = [5, 3; -2, 3], B = I
+!
+! 3) A = [1, 3; -1, 2], B = I
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 program test_d_2x2array_eig
@@ -67,6 +69,30 @@ program test_d_2x2array_eig
     ! check results
     Aold = matmul(Q,A) - matmul(Aold,Q) 
     if (maxval(abs(Aold))>tol) then
+      call u_test_failed(__LINE__)
+    end if
+    if (abs(A(1,1)-A(2,2))>tol) then
+      call u_test_failed(__LINE__)
+    end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 3)
+  
+    ! set input
+    A(1,1) = 1d0
+    A(2,1) = -1d0
+    A(1,2) = 3d0
+    A(2,2) = 2d0
+    Aold = A
+    
+    call d_2x2array_eig(.FALSE.,A,B,Q,Z)
+    
+    ! check results
+    Aold = matmul(Q,A) - matmul(Aold,Q) 
+    if (maxval(abs(Aold))>tol) then
+      call u_test_failed(__LINE__)
+    end if
+    if (abs(A(1,1)-A(2,2))>tol) then
       call u_test_failed(__LINE__)
     end if
 

--- a/test/double/test_d_orthfact_2x2deflation.f90
+++ b/test/double/test_d_orthfact_2x2deflation.f90
@@ -1,0 +1,94 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_2x2deflation
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine test_d_orthfact_2x2deflation.
+! The following tests are run:
+!
+! 1) Q = [0.8, 0.6], D = diag([1, -1])
+! 2) Q = [0.8, 0.6], D = diag([-1, -1])
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_2x2deflation
+
+  implicit none
+  
+  ! parameter
+  real(8) :: tol = 1d1*EISCOR_DBL_EPS ! accuracy (tolerance)
+  
+  ! compute variables
+  integer, parameter :: M = 2
+  real(8) :: Q(2), D(2), Z(M,2)
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  
+  D(1) = 1d0
+  D(2) = -1d0
+  
+  call d_orthfact_2x2deflation(.FALSE.,Q,D,M,Z)
+
+  ! check Q
+  if (abs(Q(1)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! check D
+  if (abs(D(1)+1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(2)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  
+  D(1) = -1d0
+  D(2) = -1d0
+  
+  call d_orthfact_2x2deflation(.FALSE.,Q,D,M,Z)
+
+  ! check Q
+  if (abs(Q(1)+8d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(2)+6d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! check D
+  if (abs(D(1)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(2)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthfact_2x2deflation

--- a/test/double/test_d_orthfact_2x2diagblock.f90
+++ b/test/double/test_d_orthfact_2x2diagblock.f90
@@ -1,0 +1,90 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_2x2diagblock
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine test_d_orthfact_2x2diagblock.
+! The following tests are run:
+!
+! 1) Q1=[0.8, 0.6], Q2=[0.5,sqrt(3)/2], Q3=[-1/sqrt(2),1/sqrt(2)],
+!    D = diag([1, -1, -1, 1])
+!    The blocks (1:2,1:2), (2:3,2:3), and (3:4,3:4) are checked.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_2x2diagblock
+
+  implicit none
+  
+  ! parameter
+  real(8) :: tol = 1d1*EISCOR_DBL_EPS ! accuracy (tolerance)
+  
+  ! compute variables
+  real(8) :: Q(6) ! N = 4
+  real(8) :: D(4)
+  real(8) :: H(2,2)
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  Q(3) = 5d-1
+  Q(4) = -sqrt(3d0)/2d0
+  Q(5) = -1d0/sqrt(2d0)
+  Q(6) = 1d0/sqrt(2d0)
+  
+  D(1) = 1d0
+  D(2) = -1d0
+  D(3) = -1d0
+  D(4) = 1d0
+
+  call d_orthfact_2x2diagblock(.TRUE.,Q(1:4),D(1:2),H)
+
+  ! check H
+  if (abs(H(1,1)-8d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,1)-6d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(1,2)-3d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,2)+4d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  
+  call d_orthfact_2x2diagblock(.FALSE.,Q(3:6),D(3:4),H)
+
+  ! check H
+  if (abs(H(1,1)-5d-1/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,1)+1d0/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(1,2)+5d-1/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,2)+1d0/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthfact_2x2diagblock

--- a/test/double/test_d_orthfact_buildbulge.f90
+++ b/test/double/test_d_orthfact_buildbulge.f90
@@ -1,0 +1,126 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_buildbulge
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine test_d_orthfact_buildbulge
+! The following tests are run:
+!
+! 1) check with orthogonal Q and unit digaonal D
+!    Q1=[0.8, 0.6], Q2=[0.5,sqrt(3)/2], Q3=[-1,eps/2], 
+!    Q4=[-1/sqrt(2),1/sqrt(2)],
+!    D = diag([1, -1, -1, 1, 1])
+!    single shift 1.0
+!
+! 2) check with orthogonal Q and unit digaonal D
+!    Q1=[0.8, 0.6], Q2=[0.5,sqrt(3)/2], Q3=[-1,eps/2], 
+!    Q4=[-1/sqrt(2),1/sqrt(2)],
+!    D = diag([1, -1, -1, 1, 1])
+!    double shift 0.5 +- i*sqrt(3)/2
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! 
+! Notes:
+!
+! A = [ 0.8   0.3     ... ]
+!     [ 0.6  -0.4     ... ]
+!     [  0  sqrt(3)/2 ... ]
+!     [ ...    0      ... ]
+!
+! mu = alpha + i beta
+! A^2e_1 - 2alpha Ae_1 + (alpha^2 + beta^2)e_1 = 
+! = [  1.02        ]
+!   [ -0.36        ]
+!   [  0.3*sqrt(3) ]
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_buildbulge
+
+  implicit none
+  
+  ! parameter
+  real(8) :: tol = 1d1*EISCOR_DBL_EPS ! accuracy (tolerance)
+  
+  ! compute variables
+  real(8) :: Q(8), Qs(8) ! N = 5
+  real(8) :: D(5), Ds(5)
+  real(8) :: E(2), Es(2)
+  real(8) :: B1(2), B2(2)
+
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  Q(3) = 5d-1
+  Q(4) = -sqrt(3d0)/2d0
+  Q(5) = -1d0
+  Q(6) = tol/2d1
+  Q(7) = -1d0/sqrt(2d0)
+  Q(8) = 1d0/sqrt(2d0)
+  
+  D(1) = 1d0
+  D(2) = -1d0
+  D(3) = -1d0
+  D(4) = 1d0
+  D(5) = 1d0
+
+  E(1) = 1d0
+  E(2) = 0d0
+
+  Qs = Q
+  Ds = D
+  Es = E
+  call d_orthfact_buildbulge(.FALSE.,Q(1:4),D(1:2),E,B1,B2)
+
+  ! check B1
+  if (abs(B1(1)+1d0/sqrt(10d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(B1(2)-3d0/sqrt(10d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+  Q = Qs
+  D = Ds
+  E(1) = 5d-1
+  E(2) = sqrt(3d0)/2d0
+  call d_orthfact_buildbulge(.TRUE.,Q(1:4),D(1:2),E,B1,B2)
+
+  ! check B1
+  if (abs(B1(1)+0.36d0/sqrt(0.3996d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(B1(2)-0.3d0/sqrt(0.3996d0)*sqrt(3d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  ! check B2
+  if (abs(B2(1)-1.02d0/1.2d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(B2(2)-sqrt(0.3996d0)/1.2d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthfact_buildbulge

--- a/test/double/test_d_orthfact_deflationcheck.f90
+++ b/test/double/test_d_orthfact_deflationcheck.f90
@@ -1,0 +1,171 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_deflationcheck
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine test_d_orthfact_deflationcheck.
+! The following tests are run:
+!
+! 1) no deflation in 
+!    Q1=[0.8, 0.6], Q2=[0.5,sqrt(3)/2], Q3=[-1/sqrt(2),1/sqrt(2)],
+!    D = diag([1, -1, -1, 1])
+!
+! 2) deflation in position 3
+!    Q1=[0.8, 0.6], Q2=[0.5,sqrt(3)/2], Q3=[-1,eps/2], 
+!    Q4=[-1/sqrt(2),1/sqrt(2)],
+!    D = diag([1, -1, -1, 1, 1])
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_deflationcheck
+
+  implicit none
+  
+  ! parameter
+  real(8) :: tol = 1d1*EISCOR_DBL_EPS ! accuracy (tolerance)
+  
+  ! compute variables
+  integer :: zero
+  real(8) :: Q(8) ! N = 5
+  real(8) :: D(5)
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  Q(3) = 5d-1
+  Q(4) = -sqrt(3d0)/2d0
+  Q(5) = -1d0/sqrt(2d0)
+  Q(6) = 1d0/sqrt(2d0)
+  
+  D(1) = 1d0
+  D(2) = -1d0
+  D(3) = -1d0
+  D(4) = 1d0
+  
+  call d_orthfact_deflationcheck(4,Q,D,zero)
+
+  ! check Q
+  if (abs(Q(1)-8d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(2)-6d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(3)-5d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(4)+sqrt(3d0)/2d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(5)+1d0/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(6)-1d0/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! check D
+  if (abs(D(1)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(2)+1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(3)+1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(4)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! check integers
+  if (zero.NE.0) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  Q(3) = 5d-1
+  Q(4) = -sqrt(3d0)/2d0
+  Q(5) = -1d0
+  Q(6) = tol/2d1
+  Q(7) = -1d0/sqrt(2d0)
+  Q(8) = 1d0/sqrt(2d0)
+  
+  D(1) = 1d0
+  D(2) = -1d0
+  D(3) = -1d0
+  D(4) = 1d0
+  D(5) = 1d0
+  
+  call d_orthfact_deflationcheck(5,Q,D,zero)
+
+  ! check Q
+  if (abs(Q(1)-8d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(2)-6d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(3)-5d-1)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(4)+sqrt(3d0)/2d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(5)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(6))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(7)+1d0/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(Q(8)+1d0/sqrt(2d0))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! check D
+  if (abs(D(1)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(2)+1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(3)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(4)+1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(D(5)-1d0)>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! check integers
+  if (zero.NE.3) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthfact_deflationcheck

--- a/test/double/test_d_orthfact_factorcheck.f90
+++ b/test/double/test_d_orthfact_factorcheck.f90
@@ -1,0 +1,223 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_factorcheck
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine test_d_orthfact_factorcheck.
+! The following tests are run:
+!
+! 1) check with orthogonal Q and unit digaonal D
+!    Q1=[0.8, 0.6], Q2=[0.5,sqrt(3)/2], Q3=[-1,eps/2], 
+!    Q4=[-1/sqrt(2),1/sqrt(2)],
+!    D = diag([1, -1, -1, 1, 1])
+! 
+! 2) perturb N
+!
+! 3) perturb Q1, then Q2, then Q3, then Q4
+!
+! 4) perturb D(1), D(2), D(3), D(4), D(5), D(6), D(7), D(8), D(9), D(10)
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_factorcheck
+
+  implicit none
+  
+  ! parameter
+  real(8) :: tol = 1d1*EISCOR_DBL_EPS ! accuracy (tolerance)
+  
+  ! compute variables
+  integer :: INFO
+  real(8) :: Q(8), Qs(8) ! N = 5
+  real(8) :: D(5), Ds(5)
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+  Q(1) = 8d-1
+  Q(2) = 6d-1
+  Q(3) = 5d-1
+  Q(4) = -sqrt(3d0)/2d0
+  Q(5) = -1d0
+  Q(6) = tol/2d1
+  Q(7) = -1d0/sqrt(2d0)
+  Q(8) = 1d0/sqrt(2d0)
+  
+  D(1) = 1d0
+  D(2) = -1d0
+  D(3) = -1d0
+  D(4) = 1d0
+  D(5) = 1d0
+
+  Qs = Q
+  Ds = D
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.0) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+  Q = Qs
+  D = Ds
+  call d_orthfact_factorcheck(1,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-1) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 3)
+  Q = Qs
+  D = Ds
+  Q(1) = Q(1)+10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(2) = Q(2)-10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(3) = Q(3)+10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(4) = Q(4)-10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(5) = Q(5)+10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(6) = 0.1
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(7) = Q(7)+10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  Q(8) = Q(8)-10*tol
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-2) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 4)
+  Q = Qs
+  D = Ds
+  D(1) = 0.2d0
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-3) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  D(2) = -2d0
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-3) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  D(3) = -.9d0
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-3) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  D(4) = 1d-300
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-3) then
+     call u_test_failed(__LINE__)
+  end if
+
+  Q = Qs
+  D = Ds
+  D(5) = 5d0
+  call d_orthfact_factorcheck(5,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.-3) then
+     call u_test_failed(__LINE__)
+  end if
+
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthfact_factorcheck

--- a/test/double/test_d_orthfact_mergebulge.f90
+++ b/test/double/test_d_orthfact_mergebulge.f90
@@ -132,7 +132,6 @@ program test_d_orthfact_mergebulge
      call u_test_failed(__LINE__)
   end if
   
-  
   ! stop timer
   call system_clock(count=c_stop)
   

--- a/test/double/test_d_orthfact_mergebulge.f90
+++ b/test/double/test_d_orthfact_mergebulge.f90
@@ -1,0 +1,142 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_mergebulge
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine d_orthfact_mergebulge (fuse rotation). 
+! The following tests are run (once with .TRUE. and once with .FALSE.):
+!
+! 1)  fuse([2/sqrt(5),1/sqrt(5)], [2/sqrt(5),-1/sqrt(5)])
+! 2)  fuse([-2/sqrt(5),1/sqrt(5)], [2/sqrt(5),1/sqrt(5)])
+! 3)  fuse([0.6, 0.8], [0.8,0.6])
+! 4)  fuse([0.6, 0.8], [-0.8,-0.6])
+!
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_mergebulge
+
+  implicit none
+
+  ! parameter
+  real(8) :: tol = 2d0*EISCOR_DBL_EPS ! accuracy (tolerance)
+
+  ! compute variables
+  logical :: top
+  real(8) :: A(2), B(2), C(2), D(2), e, f, nrm
+
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+
+  ! print banner
+  call u_test_banner(__FILE__)
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+
+  ! set variables
+  e = 2d0
+  f = 1d0
+  call d_rot2_vec2gen(e,f,B(1),B(2),nrm)
+  e = 2d0
+  f = -1d0
+  call d_rot2_vec2gen(e,f,A(1),A(2),nrm)
+  C = A
+  D = B
+
+  top = .FALSE.
+  call d_orthfact_mergebulge(top,A,B)
+
+  top = .TRUE.
+  call d_orthfact_mergebulge(top,C,D)
+
+  ! check result
+  if (maxval(abs(A-C))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+
+  ! set variables
+  e = -2d0
+  f = 1d0
+  call d_rot2_vec2gen(e,f,B(1),B(2),nrm)
+  e = 2d0
+  f = 1d0
+  call d_rot2_vec2gen(e,f,A(1),A(2),nrm)
+  C = A
+  D = B
+
+  top = .FALSE.
+  call d_orthfact_mergebulge(top,A,B)
+
+  top = .TRUE.
+  call d_orthfact_mergebulge(top,C,D)
+
+  ! check result
+  if (maxval(abs(A-C))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 3)
+
+  ! set variables
+  e = 3d0
+  f = 4d0
+  call d_rot2_vec2gen(e,f,B(1),B(2),nrm)
+  e = 4d0
+  f = 3d0
+  call d_rot2_vec2gen(e,f,A(1),A(2),nrm)
+  C = A
+  D = B
+
+  top = .FALSE.
+  call d_orthfact_mergebulge(top,A,B)
+
+  top = .TRUE.
+  call d_orthfact_mergebulge(top,C,D)
+
+  ! check result
+  if (maxval(abs(A-C))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 4)
+
+  ! set variables
+  e = 3d0
+  f = 4d0
+  call d_rot2_vec2gen(e,f,B(1),B(2),nrm)
+  e = -4d0
+  f = -3d0
+  call d_rot2_vec2gen(e,f,A(1),A(2),nrm)
+  C = A
+  D = B
+
+  top = .FALSE.
+  call d_orthfact_mergebulge(top,A,B)
+
+  top = .TRUE.
+  call d_orthfact_mergebulge(top,C,D)
+
+  ! check result
+  if (maxval(abs(A-C))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  
+  
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+  
+end program test_d_orthfact_mergebulge

--- a/test/double/test_d_orthfact_qr.f90
+++ b/test/double/test_d_orthfact_qr.f90
@@ -1,0 +1,102 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthfact_qr
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine d_orthfact_qr. The following tests are run:
+!
+! 1) Compute roots of unity and checks the residuals for various powers of 2
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthfact_qr
+
+  implicit none
+  
+  ! compute variables
+  integer, parameter :: MPOW = 4
+  integer, parameter :: N = 2**MPOW
+  integer :: ii, INFO, jj, M
+  real(8) :: Q(2*(N-1)), D(N)
+  real(8) :: H(N,N), Z(N,N), T(N,N), block(2,2)
+  integer :: ITS(N-1)
+  real(8) :: tol
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  ! loop through powers of 2
+  do jj=1,MPOW
+  
+    ! set current degree
+    M = 2**jj
+  
+    ! initialize H to be an upper hessenberg permutation matrix
+    H = 0d0
+    do ii=1,M-1
+      H(ii+1,ii) = 1d0
+    end do
+    H(1,M) = 1d0
+   
+    ! initialize Q
+    Q = 0d0
+    do ii=1,M-1
+      Q(2*ii) = 1d0
+    end do
+ 
+    ! initialize D
+    D = 1d0
+    D(M) = (-1d0)**(M-1)
+
+    ! call dohfqr
+    call d_orthfact_qr(.TRUE.,.TRUE.,M,Q,D,M,Z(1:M,1:M),ITS,INFO)
+
+    ! check INFO
+    if (INFO.NE.0) then
+      call u_test_failed(__LINE__)
+    end if
+
+    ! initialize T
+    T = 0d0
+    do ii=1,M
+      T(ii,ii) = 1d0
+    end do
+    do ii=1,(M-1)
+      block(1,1) = Q(2*ii-1)
+      block(2,1) = Q(2*ii)
+      block(1,2) = -Q(2*ii)
+      block(2,2) = Q(2*ii-1)
+      T(1:M,ii:(ii+1)) = matmul(T(1:M,ii:(ii+1)),block)
+    end do
+    do ii=1,M
+      T(1:M,ii) = T(1:M,ii)*D(ii)
+    end do
+    
+    ! compute residual matrix
+    H(1:M,1:M) = matmul(H(1:M,1:M),Z(1:M,1:M)) - matmul(Z(1:M,1:M),T(1:M,1:M))
+    
+    ! set tolerance
+    tol = max(10d0,dble(M))*EISCOR_DBL_EPS
+    
+    ! check maximum entry
+    if (maxval(abs(H(1:M,1:M))) >= tol) then
+      call u_test_failed(__LINE__)
+    end if  
+ 
+  end do
+  
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthfact_qr

--- a/test/double/test_d_orthhess_factor.f90
+++ b/test/double/test_d_orthhess_factor.f90
@@ -1,0 +1,180 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthhess_factor
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine test_d_orthhess_factor.
+! The following tests are run:
+!
+! 1)  Test cyclic for N = 2**i, i = 1, ..., 12
+!     [ 0 0 ... 0 1]
+!     [ 1 0 ... 0 0]
+!     [ 0 1 ... 0 0]
+!     [ ... ... ...]
+!     [ 0 0 ... 1 0]
+!
+! 2) Q, D given => H d_orthhess_factor has to 
+!    reproduce Q and D, N = 17
+!
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthhess_factor
+
+  implicit none
+  
+  ! parameter
+  real(8) :: tol = 1d1*EISCOR_DBL_EPS ! accuracy (tolerance)
+  integer, parameter :: MMAX = 12
+  integer, parameter :: NMAX = 2**12
+  
+  ! compute variables
+  integer :: N, M, ii, jj, INFO
+  real(8) :: Q(2*(NMAX-1))
+  real(8) :: D(NMAX), nrm
+  real(8), allocatable :: H(:,:), A(:,:), B(:,:), H2(:,:), Ho(:,:)
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+  do ii=1,MMAX
+     N = 2**ii
+     allocate(H(N,N))
+     H = 0d0
+     do jj=1,N-1
+        H(jj+1,jj) = 1d0
+     end do
+     H (1,N) = 1d0
+     
+     call d_orthhess_factor(N,H,Q,D,INFO)
+         
+     ! check info
+     if (INFO.NE.0) then
+        call u_test_failed(__LINE__)
+     end if
+  
+     do jj=1,N-1
+        ! check Q
+        if (abs(Q(2*jj-1))>tol) then
+           call u_test_failed(__LINE__)
+        end if
+        if (abs(Q(2*jj)-1d0)>tol) then
+           call u_test_failed(__LINE__)
+        end if
+        ! check D
+        if (abs(D(jj)-1d0)>tol) then
+           call u_test_failed(__LINE__)
+        end if
+     end do
+     if (abs(D(N)+1d0)>tol) then
+        call u_test_failed(__LINE__)
+     end if
+     deallocate(H)
+  end do
+
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+  N = 17
+  allocate(H(N,N),H2(N,N),Ho(N,N),A(N,N),B(N,N))
+  H = 0d0
+  do jj=1,N
+     H(jj,jj) = 1d0
+  end do
+  A = H
+  
+  D = 0d0
+  do jj=1,8
+     D(2*jj-1) =  1d0
+     D(2*jj) = -1d0
+  end do
+  D(N) = 1d0
+  
+  call d_rot2_vec2gen(1d0,2d0,Q(1),Q(2),nrm)
+  call d_rot2_vec2gen(2d0,1d0,Q(3),Q(4),nrm)
+  call d_rot2_vec2gen(3d0,-5d0,Q(5),Q(6),nrm)
+  call d_rot2_vec2gen(-1d0,6d0,Q(7),Q(8),nrm)
+  call d_rot2_vec2gen(2d0,2d0,Q(9),Q(10),nrm)
+  call d_rot2_vec2gen(3d0,-1d0,Q(11),Q(12),nrm)
+  call d_rot2_vec2gen(1d0,5d0,Q(13),Q(14),nrm)
+  call d_rot2_vec2gen(-2d0,6d0,Q(15),Q(16),nrm)
+  call d_rot2_vec2gen(3d0,-2d0,Q(17),Q(18),nrm)
+  call d_rot2_vec2gen(9d0,1d0,Q(19),Q(20),nrm)
+  call d_rot2_vec2gen(8d0,5d0,Q(21),Q(22),nrm)
+  call d_rot2_vec2gen(-7d0,-6d0,Q(23),Q(24),nrm)
+  call d_rot2_vec2gen(6d0,2d0,Q(25),Q(26),nrm)
+  call d_rot2_vec2gen(5d0,1d0,Q(27),Q(28),nrm)
+  call d_rot2_vec2gen(4d0,-5d0,Q(29),Q(30),nrm)
+  call d_rot2_vec2gen(-3d0,6d0,Q(31),Q(32),nrm)
+  do jj=1,N-1
+     B = A
+     B(jj,jj) = Q(2*jj-1)
+     B(jj+1,jj) = Q(2*jj)
+     B(jj,jj+1) = -Q(2*jj)
+     B(jj+1,jj+1) = Q(2*jj-1)
+     H = matmul(H,B)
+  end do
+  do jj=1,N
+     H(:,jj) = H(:,jj)*D(jj)
+  end do
+  Ho = H
+  
+  call d_orthhess_factor(N,H,Q,D,INFO)
+
+  ! check info
+  if (INFO.NE.0) then
+     call u_test_failed(__LINE__)
+  end if
+  
+  ! check D
+  do jj=1,N
+     if (abs(abs(D(jj))-1d0)>tol) then
+        call u_test_failed(__LINE__)
+     end if
+  end do
+
+  H2 = A
+  do jj=1,N-1
+     B = A
+     B(jj,jj) = Q(2*jj-1)
+     B(jj+1,jj) = Q(2*jj)
+     B(jj,jj+1) = -Q(2*jj)
+     B(jj+1,jj+1) = Q(2*jj-1)
+     H2 = matmul(H2,B)
+  end do
+  do jj=1,N
+     H2(:,jj) = H2(:,jj)*D(jj)
+  end do
+
+  ! compare H2 with Ho
+  do ii=1,N-1
+     do jj=1,ii+1
+        if (abs(Ho(jj,ii)-H2(jj,ii))>tol) then
+           if (DEBUG) then
+              print*, "H2 does not agree with H in position", jj,",", ii
+           end if
+           print*, "H2 does not agree with H in position", jj,",", ii
+           call u_test_failed(__LINE__)
+        end if
+     end do
+  end do
+
+  deallocate(H,H2,Ho,A,B)  
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthhess_factor

--- a/test/double/test_d_orthhess_qr.f90
+++ b/test/double/test_d_orthhess_qr.f90
@@ -1,0 +1,77 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_orthhess_qr
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine d_orthhess_qr. The following tests are run:
+!
+! 1) Compute roots of unity and checks the residuals for various powers of 2
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_orthhess_qr
+
+  implicit none
+  
+  ! compute variables
+  integer, parameter :: MPOW = 4
+  integer, parameter :: N = 2**MPOW
+  integer :: ii, INFO, jj, M
+  real(8) :: WORK(3*N), Hold(N,N), H(N,N), Z(N,N)
+  integer :: ITS(N-1)
+  real(8) :: tol
+  
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+  
+  ! print banner
+  call u_test_banner(__FILE__)
+  
+  ! loop through powers of 2
+  do jj=1,MPOW
+  
+    ! set current degree
+    M = 2**jj
+
+    ! initialize H to be an upper hessenberg permutation matrix
+    H = 0d0
+    do ii=1,M-1
+      H(ii+1,ii) = 1d0
+    end do
+    H(1,M) = 1d0
+    Hold = H
+    
+
+    ! call dohfqr
+    call d_orthhess_qr(.TRUE.,.TRUE.,M,H(1:M,1:M),WORK,M,Z(1:M,1:M),ITS,INFO)
+    
+    ! check INFO
+    if (INFO.NE.0) then
+      call u_test_failed(__LINE__)
+    end if
+    
+    ! compute residual matrix
+    Hold(1:M,1:M) = matmul(Hold(1:M,1:M),Z(1:M,1:M))-matmul(Z(1:M,1:M),H(1:M,1:M))
+    
+    ! set tolerance
+    tol = max(10d0,dble(M))*EISCOR_DBL_EPS
+    
+    ! check maximum entry
+    if (maxval(abs(Hold(1:M,1:M))) >= tol) then
+      call u_test_failed(__LINE__)
+    end if  
+ 
+  end do
+  
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+     
+end program test_d_orthhess_qr

--- a/test/double/test_d_rot2_swapdiag.f90
+++ b/test/double/test_d_rot2_swapdiag.f90
@@ -1,0 +1,169 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_rot2_swapdiag
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine d_rot2_swapdiag (swap rotation and diagonal). 
+!
+! 1)  D = diag([ 1  1]), B = [2/sign(5), 1/sign(5)]!
+! 2)  D = diag([-1  1]), B = [1/sign(5), -2/sign(5)]
+! 3)  D = diag([ 1 -1]), B = [-3/5, 4/5]
+! 4)  D = diag([-1 -1]), B = [0,1]
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_rot2_swapdiag
+
+  implicit none
+
+  ! parameter
+  real(8) :: tol = 2d0*EISCOR_DBL_EPS ! accuracy (tolerance)
+
+  ! compute variables
+  real(8) :: D(2), B(2), a, c, nrm
+
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start)
+
+  ! print banner
+  call u_test_banner(__FILE__)
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 1)
+
+  ! set variables
+  D(1) = 1d0
+  D(2) = 1d0
+  a = 2d0
+  c = 1d0
+  call d_rot2_vec2gen(a,c,B(1),B(2),nrm)
+
+  ! compute H
+  H(1,1) = B(1)*D(1)
+  H(2,1) = B(2)*D(1)
+  H(1,2) = -B(2)*D(2)
+  H(2,2) = B(1)*D(2)
+
+  call d_rot2_swapdiag(D,B)
+
+  if (abs(H(1,1)-B(1)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,1)-B(2)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(1,2)+B(2)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,2)-B(1)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 2)
+
+  ! set variables
+  D(1) = -1d0
+  D(2) = 1d0
+  a = 1d0
+  c = -2d0
+  call d_rot2_vec2gen(a,c,B(1),B(2),nrm)
+
+  ! compute H
+  H(1,1) = B(1)*D(1)
+  H(2,1) = B(2)*D(1)
+  H(1,2) = -B(2)*D(2)
+  H(2,2) = B(1)*D(2)
+
+  call d_rot2_swapdiag(D,B)
+
+  if (abs(H(1,1)-B(1)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,1)-B(2)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(1,2)+B(2)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,2)-B(1)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 3)
+
+  ! set variables
+  D(1) = 1d0
+  D(2) = -1d0
+  a = -3d0
+  c = 4d0
+  call d_rot2_vec2gen(a,c,B(1),B(2),nrm)
+
+  ! compute H
+  H(1,1) = B(1)*D(1)
+  H(2,1) = B(2)*D(1)
+  H(1,2) = -B(2)*D(2)
+  H(2,2) = B(1)*D(2)
+
+  call d_rot2_swapdiag(D,B)
+
+  if (abs(H(1,1)-B(1)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,1)-B(2)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(1,2)+B(2)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,2)-B(1)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+
+  !!!!!!!!!!!!!!!!!!!!
+  ! check 4)
+
+  ! set variables
+  D(1) = -1d0
+  D(2) = -1d0
+  a = 0d0
+  c = 1d0
+  call d_rot2_vec2gen(a,c,B(1),B(2),nrm)
+
+  ! compute H
+  H(1,1) = B(1)*D(1)
+  H(2,1) = B(2)*D(1)
+  H(1,2) = -B(2)*D(2)
+  H(2,2) = B(1)*D(2)
+
+  call d_rot2_swapdiag(D,B)
+
+  if (abs(H(1,1)-B(1)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,1)-B(2)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(1,2)+B(2)*D(1))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+  if (abs(H(2,2)-B(1)*D(2))>tol) then
+     call u_test_failed(__LINE__)
+  end if
+
+  ! stop timer
+  call system_clock(count=c_stop)
+
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+
+end program test_d_rot2_swapdiag

--- a/test/double/test_d_rot2_swapdiag.f90
+++ b/test/double/test_d_rot2_swapdiag.f90
@@ -21,7 +21,7 @@ program test_d_rot2_swapdiag
   real(8) :: tol = 2d0*EISCOR_DBL_EPS ! accuracy (tolerance)
 
   ! compute variables
-  real(8) :: D(2), B(2), a, c, nrm
+  real(8) :: H(2,2), D(2), B(2), a, c, nrm
 
   ! timing variables
   integer:: c_start, c_stop, c_rate

--- a/test/double/test_d_rot2_turnover.f90
+++ b/test/double/test_d_rot2_turnover.f90
@@ -43,7 +43,7 @@ program test_d_rot2_turnover
   integer, allocatable :: seed(:)
   real(8) :: Q1(2), Q2(2), Q3(2)
   real(8) :: time
-  real(8) :: rp, nrm, pi = 3.141592653589793239d0
+  real(8) :: rp, nrm, pi = EISCOR_DBL_PI
 
   ! timing variables
   integer:: c_start, c_stop, c_rate

--- a/test/double/test_d_rot2_turnover.f90
+++ b/test/double/test_d_rot2_turnover.f90
@@ -1,0 +1,821 @@
+#include "eiscor.h"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! test_d_rot2_turnover
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! This program tests the subroutine d_rot2_turnover (turnover). The following 
+! tests are run:
+!
+! 1) three random rotations
+! 2) one almost diagonal rotation
+! 3) two almost diagonal rotations
+! 4) three almost diagonal rotations
+! 5) one almost anti-diagonal rotation
+! 6) two almost anti-diagonal rotations
+! 7) three almost anti-diagonal rotations
+! 8) repeating 2), 3), 5), and 6) with one/two exact (anti-)diagonal rotations
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! If DEBUG mode is activated a histogram of the accuracy of the turnover is 
+! printed. The program compares the histogram to a reference histogram. If the
+! histogram is equal or better than the reference, then the test is passed.
+! 
+! A deviation of 0.2% is still acceptable.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+program test_d_rot2_turnover
+  
+  implicit none
+  
+  ! parameter
+  integer, parameter :: nt = 120000 ! number of testcases
+  integer :: accum = 100 ! number of successive turnovers
+                         ! (deterioration)
+  real(8) :: tol
+
+  ! compute variables
+  logical :: pass_all = .TRUE.
+  logical :: pass_cur
+  integer :: ii, n, jj, INFO
+  integer, allocatable :: seed(:)
+  real(8) :: Q1(2), Q2(2), Q3(2)
+  real(8) :: time
+  real(8) :: rp, nrm, pi = 3.141592653589793239d0
+
+  ! timing variables
+  integer:: c_start, c_stop, c_rate
+
+  ! debug
+  integer :: histo(7), histo2(7,8), histot(7,8), h2, ht
+
+  ! tol depending on accum
+  tol = 2d0*accum*epsilon(1d0) ! accuracy of turnover
+
+  ! fix seed
+  INFO = 0
+  ! get size of see        
+  call random_seed(size = n)
+  ! allocate memory for seed
+  allocate(seed(n))  
+  ! check allocation
+  if (allocated(seed).EQV..FALSE.) then
+    call u_test_failed(__LINE__)
+  end if   
+  ! store seeds    
+  seed = 0
+  seed(1) = 232419
+  !seed(1) = 377679
+  if (n>=12) then
+     seed(2) = 154653 
+     seed(3) = 331669 
+     seed(4) = 194341
+     seed(5) = 1451740
+     seed(6) = 3974222
+     seed(7) = 1274552
+     seed(8) = 4130946
+     seed(9) = 3816048
+     seed(10) = 4989015
+     seed(11) = 933389
+     seed(12) = 4989015
+  end if
+  ! set the generator
+  call random_seed(put = seed) 
+  ! free memory        
+  deallocate(seed)
+  
+  ! start timer
+  call system_clock(count_rate=c_rate)
+  call system_clock(count=c_start) 
+  ! print banner
+  call u_test_banner(__FILE__)
+
+  ! set accum to a even number
+  if (mod(accum,2)==1) then
+     accum=accum+1;
+  end if
+
+  ! Arbitrary random
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,1)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! one close to diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,2)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! two close to diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,3)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! three close to diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do 
+  histo2(1:7,4)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! one close to anti-diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,5)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! two close to anti-diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/3
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,6)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! three close to anti-diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,7)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  ! some rotations exact diagonal / exact anti-diagonal
+  pass_cur = .TRUE.
+  histo = 0
+  do ii=1,nt/12
+     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm,INFO)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  histo2(1:7,8)=histo(1:7)
+  if (DEBUG) then
+     if (.NOT.pass_cur) then
+        write(*,*) ""
+        write(*,*) "Arbitrary random rotation"
+        write(*,*) ""
+        write(*,*) "<1e-17",histo(1)
+        write(*,*) "<1e-16",histo(2)
+        write(*,*) "<1e-15",histo(3)
+        write(*,*) "<1e-14",histo(4)
+        write(*,*) "<1e-13",histo(5)
+        write(*,*) "<1e-12",histo(6)
+        write(*,*) ">1e-12",histo(7)
+        write(*,*) "FAILED."
+        pass_all = .FALSE.
+     end if
+  else
+     if (.NOT. pass_cur) then
+        call u_test_failed(__LINE__)
+     end if
+  end if
+
+  if (DEBUG) then
+     ! print histogram
+     write(*,*) ""
+     write(*,*) "<1e-17",histo2(1,:)
+     write(*,*) "<1e-16",histo2(2,:)
+     write(*,*) "<1e-15",histo2(3,:)
+     write(*,*) "<1e-14",histo2(4,:)
+     write(*,*) "<1e-13",histo2(5,:)
+     write(*,*) "<1e-12",histo2(6,:)
+     write(*,*) ">1e-12",histo2(7,:)
+  end if
+
+  ! reference histogram, turnover passes test if histogram is better than this one
+  histot(1,:) = (/           0,       12000,       60000,      120000,           0,      118000,      120000,       60000/)!
+  histot(2,:) = (/           0,        8000,        5000,           0,           0,           0,           0,        3000/)!
+  histot(3,:) = (/       67000,       78000,       50000,           0,       79000,        2000,           0,       42000/)!
+  histot(4,:) = (/       52000,       21500,        5000,           0,       40000,           0,           0,       14600/)!
+  histot(5,:) = (/        1000,         500,           0,           0,        1000,           0,           0,         400/)!
+  histot(6,:) = (/           0,           0,           0,           0,           0,           0,           0,           0/)!
+  histot(7,:) = (/           0,           0,           0,           0,           0,           0,           0,           0/)!
+
+  ! compare histogram
+  do jj=1,8
+     h2 = histo2(7,jj)
+     ht = histot(7,jj)
+     do ii=7,1,-1
+        if (h2>ht*1.002) then
+           if (DEBUG) then
+              pass_all = .FALSE.
+           else
+              call u_test_failed(__LINE__)           
+           end if
+        end if
+        if (ii>1) then
+           ht = ht + histot(ii-1,jj)
+           h2 = h2 + histo2(ii-1,jj)
+        end if
+     end do
+  end do
+ 
+  if (DEBUG) then
+     if (.NOT. pass_all) then
+        write(*,*) "At least one turnover test FAILED."
+     end if
+  end if
+
+  ! stop timer
+  call system_clock(count=c_stop)
+  
+  ! print success
+  call u_test_passed(dble(c_stop-c_start)/dble(c_rate))
+
+end program test_d_rot2_turnover
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! subroutine d_rot2_accum_to_err
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! d_rot2_accum_to_err computes the 3x3 matrix Hs 
+! defined by Q1, Q2, Q3. After a turnover the new 
+! rotations define H.
+! accum-1 more turnovers are performed using the 
+! output of the last turnover. The result is the
+! matrix H'. The error is
+!   nrm = ||H'-Hs|| + ||H-Hs||.
+! If nrm<tol, then the turnover is okay.
+! Depending on nrm histo(i) is increased by one.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+! INPUT VARIABLES
+!
+!  Q1, Q2, Q3      REAL(8) arrays of dimension (2)
+!                    generators for givens rotations
+! 
+!  accum           INTEGER
+!                    number of turnovers
+!
+!  tol             REAL(8)
+!                    tolerance
+!
+!  histo           REAL(8) array of dimension (7)
+!                    stores histogram of nrm
+!
+! OUTPUT VARIABLES
+!
+!  pass_cur        LOGICAL
+!                    .FALSE. if nrm>tol
+!                    .TRUE. if nrm<=tol
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+
+  implicit none
+
+  real(8), intent(inout) :: Q1(2), Q2(2), Q3(2)
+  integer,intent(inout) :: histo(7)
+  integer, intent(in) :: accum
+  logical, intent(inout) :: pass_cur
+
+  ! compute variables
+  integer :: jj, INFO
+  real(8) :: B(2), H(3,3), Hs(3,3), A1(3,3), A2(3,3), A3(3,3)
+  real(8) :: Q1s(2), Q2s(2), Q3s(2)
+  real(8) :: tol, nrm
+  
+  ! store Q1, Q2, Q3
+  Q1s = Q1
+  Q2s = Q2
+  Q3s = Q3
+  ! compute Hs
+  A1=0d0
+  A2=0d0
+  A3=0d0
+  A1(1,1)=Q1(1)
+  A1(2,1)=Q1(2)
+  A1(1,2)=-Q1(2)
+  A1(2,2)=Q1(1)
+  A1(3,3)=1d0
+  A2(2,2)=Q2(1)
+  A2(3,2)=Q2(2)
+  A2(2,3)=-Q2(2)
+  A2(3,3)=Q2(1)
+  A2(1,1)=1d0
+  A3(1,1)=Q3(1)
+  A3(2,1)=Q3(2)
+  A3(1,2)=-Q3(2)
+  A3(2,2)=Q3(1)
+  A3(3,3)=1d0
+  Hs = matmul(A1,matmul(A2,A3))
+
+  ! first turnover
+  call d_rot2_turnover(Q1,Q2,Q3,INFO)
+  ! check INFO
+  if (INFO.NE.0) then
+     call u_test_failed(__LINE__)
+  end if
+  ! switch position of rotations
+  B = Q1
+  Q1 = Q3
+  Q3 = Q2
+  Q2 = B
+
+  ! compute H
+  A1=0d0
+  A2=0d0
+  A3=0d0
+  A1(2,2)=Q1(1)
+  A1(3,2)=Q1(2)
+  A1(2,3)=-Q1(2)
+  A1(3,3)=Q1(1)
+  A1(1,1)=1d0
+  A2(1,1)=Q2(1)
+  A2(2,1)=Q2(2)
+  A2(1,2)=-Q2(2)
+  A2(2,2)=Q2(1)
+  A2(3,3)=1d0
+  A3(2,2)=Q3(1)
+  A3(3,2)=Q3(2)
+  A3(2,3)=-Q3(2)
+  A3(3,3)=Q3(1)
+  A3(1,1)=1d0
+  H = matmul(A1,matmul(A2,A3))
+  H = H-Hs
+  
+  ! first part of nrm
+  nrm = sqrt(H(1,1)*H(1,1) + H(1,2)*H(1,2) + H(1,3)*H(1,3) +&
+       &H(2,1)*H(2,1) + H(2,2)*H(2,2) + H(2,3)*H(2,3) +&
+       H(3,1)*H(3,1) + H(3,2)*H(3,2) + H(3,3)*H(3,3))
+  
+  ! accum-1 turnovers
+  do jj=2,accum
+     call d_rot2_turnover(Q1,Q2,Q3,INFO)
+     ! check INFO
+     if (INFO.NE.0) then
+        call u_test_failed(__LINE__)
+     end if
+     
+     B = Q1
+     Q1 = Q3
+     Q3 = Q2
+     Q2 = B
+  end do
+  
+  ! compute H'
+  A1=0d0
+  A2=0d0
+  A3=0d0
+  A1(1,1)=Q1(1)
+  A1(2,1)=Q1(2)
+  A1(1,2)=-Q1(2)
+  A1(2,2)=Q1(1)
+  A1(3,3)=1d0
+  A2(2,2)=Q2(1)
+  A2(3,2)=Q2(2)
+  A2(2,3)=-Q2(2)
+  A2(3,3)=Q2(1)
+  A2(1,1)=1d0
+  A3(1,1)=Q3(1)
+  A3(2,1)=Q3(2)
+  A3(1,2)=-Q3(2)
+  A3(2,2)=Q3(1)
+  A3(3,3)=1d0
+  H = matmul(A1,matmul(A2,A3))
+  H = H-Hs
+
+  ! second part of nrm
+  nrm = nrm + sqrt(H(1,1)*H(1,1) + H(1,2)*H(1,2) + H(1,3)*H(1,3) +&
+       &H(2,1)*H(2,1) + H(2,2)*H(2,2) + H(2,3)*H(2,3) +&
+       H(3,1)*H(3,1) + H(3,2)*H(3,2) + H(3,3)*H(3,3))
+
+  ! check nrm
+  if (nrm>tol) then
+     pass_cur = .FALSE.
+  end if
+  if (nrm<1e-17) then
+     histo(1) = histo(1) + 1
+  else if (nrm<1e-16) then
+     histo(2) = histo(2) + 1
+  else if (nrm<1e-15) then
+     histo(3) = histo(3) + 1
+  else if (nrm<1e-14) then
+     histo(4) = histo(4) + 1
+  else if (nrm<1e-13) then
+     histo(5) = histo(5) + 1
+  else if (nrm<1e-12) then
+     histo(6) = histo(6) + 1
+  else
+     histo(7) = histo(7) + 1
+  end if
+
+end subroutine d_rot2_accum_to_err

--- a/test/double/test_d_rot2_turnover.f90
+++ b/test/double/test_d_rot2_turnover.f90
@@ -39,7 +39,7 @@ program test_d_rot2_turnover
   ! compute variables
   logical :: pass_all = .TRUE.
   logical :: pass_cur
-  integer :: ii, n, jj, INFO
+  integer :: ii, n, jj
   integer, allocatable :: seed(:)
   real(8) :: Q1(2), Q2(2), Q3(2)
   real(8) :: time
@@ -52,10 +52,9 @@ program test_d_rot2_turnover
   integer :: histo(7), histo2(7,8), histot(7,8), h2, ht
 
   ! tol depending on accum
-  tol = 2d0*accum*epsilon(1d0) ! accuracy of turnover
+  tol = 2d0*accum*EISCOR_DBL_EPS ! accuracy of turnover
 
   ! fix seed
-  INFO = 0
   ! get size of see        
   call random_seed(size = n)
   ! allocate memory for seed
@@ -103,13 +102,13 @@ program test_d_rot2_turnover
   do ii=1,nt
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,1)=histo(1:7)
@@ -140,37 +139,37 @@ program test_d_rot2_turnover
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,2)=histo(1:7)
@@ -201,37 +200,37 @@ program test_d_rot2_turnover
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,3)=histo(1:7)
@@ -262,13 +261,13 @@ program test_d_rot2_turnover
   do ii=1,nt
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp)*1e-18,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do 
   histo2(1:7,4)=histo(1:7)
@@ -299,37 +298,37 @@ program test_d_rot2_turnover
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,5)=histo(1:7)
@@ -360,37 +359,37 @@ program test_d_rot2_turnover
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/3
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,6)=histo(1:7)
@@ -421,13 +420,13 @@ program test_d_rot2_turnover
   do ii=1,nt
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp)*1e-18,sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,7)=histo(1:7)
@@ -456,111 +455,111 @@ program test_d_rot2_turnover
   pass_cur = .TRUE.
   histo = 0
   do ii=1,nt/12
-     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
-     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
+     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
-     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
+     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
-     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm,INFO)
-     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm)
+     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
-     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
-  end do
-  do ii=1,nt/12
-     call random_number(rp)
-     rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
-     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm,INFO)
-     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm,INFO)
-     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
-  end do
-  do ii=1,nt/12
-     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm,INFO)
-     call random_number(rp)
-     rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
-     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm,INFO)
-     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
-  end do
-  do ii=1,nt/12
-     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm,INFO)
-     call random_number(rp)
-     rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
-     call random_number(rp)
-     rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
-     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
+     call d_rot2_vec2gen(1d0,0d0,Q2(1),Q2(2),nrm)
+     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(1d0,0d0,Q1(1),Q1(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
+     call d_rot2_vec2gen(1d0,0d0,Q3(1),Q3(2),nrm)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
+     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
-     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm,INFO)
-     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
-  end do
-  do ii=1,nt/12
-     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm,INFO)
-     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm,INFO)
-     call random_number(rp)
-     rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm,INFO)
-     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm,INFO)
-     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
+     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   do ii=1,nt/12
-     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm,INFO)
+     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm)
+     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm)
      call random_number(rp)
      rp = 2d0*pi*rp
-     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm,INFO)
-     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm,INFO)
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q3(1),Q3(2),nrm)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q1(1),Q1(2),nrm)
+     call d_rot2_vec2gen(0d0,1d0,Q2(1),Q2(2),nrm)
+     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm)
+     call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
+  end do
+  do ii=1,nt/12
+     call d_rot2_vec2gen(0d0,1d0,Q1(1),Q1(2),nrm)
+     call random_number(rp)
+     rp = 2d0*pi*rp
+     call d_rot2_vec2gen(cos(rp),sin(rp),Q2(1),Q2(2),nrm)
+     call d_rot2_vec2gen(0d0,1d0,Q3(1),Q3(2),nrm)
      call d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   end do
   histo2(1:7,8)=histo(1:7)
@@ -688,7 +687,7 @@ subroutine d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   logical, intent(inout) :: pass_cur
 
   ! compute variables
-  integer :: jj, INFO
+  integer :: jj
   real(8) :: B(2), H(3,3), Hs(3,3), A1(3,3), A2(3,3), A3(3,3)
   real(8) :: Q1s(2), Q2s(2), Q3s(2)
   real(8) :: tol, nrm
@@ -719,11 +718,8 @@ subroutine d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   Hs = matmul(A1,matmul(A2,A3))
 
   ! first turnover
-  call d_rot2_turnover(Q1,Q2,Q3,INFO)
-  ! check INFO
-  if (INFO.NE.0) then
-     call u_test_failed(__LINE__)
-  end if
+  call d_rot2_turnover(Q1,Q2,Q3)
+
   ! switch position of rotations
   B = Q1
   Q1 = Q3
@@ -759,11 +755,7 @@ subroutine d_rot2_accum_to_err(Q1,Q2,Q3,accum,tol,histo,pass_cur)
   
   ! accum-1 turnovers
   do jj=2,accum
-     call d_rot2_turnover(Q1,Q2,Q3,INFO)
-     ! check INFO
-     if (INFO.NE.0) then
-        call u_test_failed(__LINE__)
-     end if
+     call d_rot2_turnover(Q1,Q2,Q3)
      
      B = Q1
      Q1 = Q3

--- a/test/double/test_d_rot2_turnover.f90
+++ b/test/double/test_d_rot2_turnover.f90
@@ -597,11 +597,11 @@ program test_d_rot2_turnover
   end if
 
   ! reference histogram, turnover passes test if histogram is better than this one
-  histot(1,:) = (/           0,       12000,       60000,      120000,           0,      118000,      120000,       60000/)!
-  histot(2,:) = (/           0,        8000,        5000,           0,           0,           0,           0,        3000/)!
-  histot(3,:) = (/       67000,       78000,       50000,           0,       79000,        2000,           0,       42000/)!
-  histot(4,:) = (/       52000,       21500,        5000,           0,       40000,           0,           0,       14600/)!
-  histot(5,:) = (/        1000,         500,           0,           0,        1000,           0,           0,         400/)!
+  histot(1,:) = (/           0,        4500,       35000,      120000,           0,       99500,      120000,       57000/)!
+  histot(2,:) = (/           0,        5000,        5000,           0,           0,           0,           0,        3000/)!
+  histot(3,:) = (/       38500,       70000,       70000,           0,       59000,       20000,           0,       35000/)!
+  histot(4,:) = (/       80000,       40000,        9900,           0,       70000,         500,           0,       24600/)!
+  histot(5,:) = (/        1500,         500,         100,           0,        1000,           0,           0,         400/)!
   histot(6,:) = (/           0,           0,           0,           0,           0,           0,           0,           0/)!
   histot(7,:) = (/           0,           0,           0,           0,           0,           0,           0,           0/)!
 
@@ -613,7 +613,7 @@ program test_d_rot2_turnover
         if (h2>ht*1.002) then
            if (DEBUG) then
               pass_all = .FALSE.
-           else
+           else             
               call u_test_failed(__LINE__)           
            end if
         end if


### PR DESCRIPTION
I've finished updating the real unitary QR code to use the simplified framework. Currently the test for 
`d_rot2_turnover` fails on my laptop. I think this is related to the histogram issue for `z_rot3_turnover`. I'm not sure what you did in that case but I think it should be repeated here. 