### PR TITLE
bugfix unitary QR: second deflation at the top of the matrix

### DIFF
--- a/src/complex_double/z_unifact_qr.f90
+++ b/src/complex_double/z_unifact_qr.f90
@@ -165,9 +165,9 @@ subroutine z_unifact_qr(VEC,ID,N,Q,D,M,Z,ITS,INFO)
     ! if greater than 2x2 chase a bulge
     else
 
-      ! check STR
-      if (STR <= ZERO) then
-        STR = ZERO+1
+      ! check ZERO
+      if (ZERO.GT.0) then
+        STR = STR+ZERO
       end if
 
       ! perform singleshift iteration

--- a/src/double/d_orthfact_qr.f90
+++ b/src/double/d_orthfact_qr.f90
@@ -162,8 +162,8 @@ subroutine d_orthfact_qr(VEC,ID,N,Q,D,M,Z,ITS,INFO)
     else
 
       ! check STR
-      if (STR <= ZERO) then
-        STR = ZERO+1
+      if (ZERO.GT.0) then
+        STR = STR+ZERO
       end if
 
       ! perform singleshift iteration


### PR DESCRIPTION
The deflations at the top of the matrix were handled incorrectly. This fix should fix this.