### PR TITLE
removing DIR variable from z_rot3_swapdiag, the direction is not necessary

### DIFF
--- a/example/complex_double/example_z_unifact_knowneigs.f90
+++ b/example/complex_double/example_z_unifact_knowneigs.f90
@@ -74,12 +74,12 @@ program example_z_unifact_knowneigs
         ! set indices
         ind = 3*(jj-1)
         ! through diag
-        call z_rot3_swapdiag(.FALSE.,D(2*jj-1:2*jj+2),b1)
+        call z_rot3_swapdiag(D(2*jj-1:2*jj+2),b1)
         call z_rot3_turnover(Q((ind+1):(ind+3)),Q((ind+4):(ind+6)),b1)
      end do
      ind = 3*(n-1)
      ! fusion at bottom
-     call z_rot3_swapdiag(.FALSE.,D((2*n-3):(2*n)),b1)
+     call z_rot3_swapdiag(D((2*n-3):(2*n)),b1)
      call z_unifact_mergebulge(.FALSE.,Q((ind-2):(ind)),D((2*n-3):(2*n)),b1)
   end do
   

--- a/src/complex_double/z_rot3_swapdiag.f90
+++ b/src/complex_double/z_rot3_swapdiag.f90
@@ -14,10 +14,6 @@
 !
 ! INPUT VARIABLES:
 !
-!  DIR             LOGICAL
-!                    .TRUE.: pass rotation from left to right
-!                    .FALSE.: pass rotation from right to left
-!
 !  D               REAL(8) array of dimension (4)
 !                    array of generators for complex diagonal matrix
 !
@@ -25,12 +21,11 @@
 !                    generator for a Givens rotation
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-subroutine z_rot3_swapdiag(DIR,D,G)
+subroutine z_rot3_swapdiag(D,G)
 
   implicit none
   
   ! input variables
-  logical, intent(in) :: DIR
   real(8), intent(inout) :: D(4), G(3)
   
   ! compute variables
@@ -50,30 +45,15 @@ subroutine z_rot3_swapdiag(DIR,D,G)
   d2r = D(3)
   d2i = D(4)  
   
-  ! from left to right
-  if (DIR)then
+  ! from right to left and left to right
+  ! pass through diagonal
+  nrm = (d1r*d2r + d1i*d2i)*c1r - (-d1r*d2i + d1i*d2r)*c1i
+  c1i = (d1r*d2r + d1i*d2i)*c1i + (-d1r*d2i + d1i*d2r)*c1r
+  c1r = nrm
   
-    ! pass through diagonal
-    nrm = (d1r*d2r + d1i*d2i)*c1r - (-d1r*d2i + d1i*d2r)*c1i
-    c1i = (d1r*d2r + d1i*d2i)*c1i + (-d1r*d2i + d1i*d2r)*c1r
-    c1r = nrm
-  
-    ! renormalize
-    call z_rot3_unitvec3gen(c1r,c1i,s1,G(1),G(2),G(3)) 
+  ! renormalize
+  call z_rot3_unitvec3gen(c1r,c1i,s1,G(1),G(2),G(3)) 
     
-  ! from right to left
-  else
-  
-    ! pass through diagonal
-    nrm = (d1r*d2r + d1i*d2i)*c1r - (-d1r*d2i + d1i*d2r)*c1i
-    c1i = (d1r*d2r + d1i*d2i)*c1i + (-d1r*d2i + d1i*d2r)*c1r
-    c1r = nrm
-  
-    ! renormalize
-    call z_rot3_unitvec3gen(c1r,c1i,s1,G(1),G(2),G(3))
-    
-  end if
-  
   ! set D
   D(1) = d2r 
   D(2) = d2i

--- a/src/complex_double/z_unifact_singlestep.f90
+++ b/src/complex_double/z_unifact_singlestep.f90
@@ -127,7 +127,7 @@ subroutine z_unifact_singlestep(VEC,N,Q,D,M,Z,ITCNT)
   call z_unifact_mergebulge(.TRUE.,Q(1:3),D(1:4),binv)
   
   ! bulge through diag
-  call z_rot3_swapdiag(.FALSE.,D(1:4),bulge)
+  call z_rot3_swapdiag(D(1:4),bulge)
 
   ! update eigenvectors
   if (VEC) then
@@ -167,7 +167,7 @@ subroutine z_unifact_singlestep(VEC,N,Q,D,M,Z,ITCNT)
     ind2 = ind1+3
      
     ! through diag
-    call z_rot3_swapdiag(.FALSE.,D(ind1:ind2),bulge)
+    call z_rot3_swapdiag(D(ind1:ind2),bulge)
 
   end do
   

--- a/src/complex_double/z_upr1fact_rot3throughtri.f90
+++ b/src/complex_double/z_upr1fact_rot3throughtri.f90
@@ -55,7 +55,7 @@ subroutine z_upr1fact_rot3throughtri(DIR,D,C,B,G)
   if (DIR) then
   
     ! through D
-    call z_rot3_swapdiag(DIR,D,G)
+    call z_rot3_swapdiag(D,G)
  
     ! through C and B, symmetric case
     if (SYM) then
@@ -117,7 +117,7 @@ subroutine z_upr1fact_rot3throughtri(DIR,D,C,B,G)
     end if
     
     ! through D
-    call z_rot3_swapdiag(DIR,D,G)
+    call z_rot3_swapdiag(D,G)
   
   end if
 

--- a/src/double/d_symtrid_factor.f90
+++ b/src/double/d_symtrid_factor.f90
@@ -239,7 +239,7 @@ subroutine d_symtrid_factor(VEC,ID,SCA,N,D,E,Q,QD,SCALE,M,Z,INFO)
         ind2 = ind1+3
         
         ! through diag 
-        call z_rot3_swapdiag(.FALSE.,QD(ind1:ind2),bulge)
+        call z_rot3_swapdiag(QD(ind1:ind2),bulge)
         
         ! set indices
         ind1 = 3*(ii-1) + 1
@@ -264,7 +264,7 @@ subroutine d_symtrid_factor(VEC,ID,SCA,N,D,E,Q,QD,SCALE,M,Z,INFO)
      ind2 = ind1+3
      
      ! through diag
-     call z_rot3_swapdiag(.FALSE.,QD(ind1:ind2),bulge)
+     call z_rot3_swapdiag(QD(ind1:ind2),bulge)
      
      ! fusion at bottom
      call z_unifact_mergebulge(.FALSE.,Q((3*N-5):(3*N-3)),QD((2*N-3):(2*N)),bulge)

--- a/test/complex_double/test_z_rot3_swapdiag.f90
+++ b/test/complex_double/test_z_rot3_swapdiag.f90
@@ -56,7 +56,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -87,7 +87,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -122,7 +122,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -154,7 +154,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -189,7 +189,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -221,7 +221,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -257,7 +257,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)
@@ -289,7 +289,7 @@ program test_z_rot3_swapdiag
   H(1,2) = -B(3)*cmplx(D(3),D(4),kind=8)
   H(2,2) = cmplx(B(1),-B(2),kind=8)*cmplx(D(3),D(4),kind=8)
 
-  call z_rot3_swapdiag(dir,D,B)
+  call z_rot3_swapdiag(D,B)
 
   if (abs(H(1,1)-cmplx(B(1),B(2),kind=8)*cmplx(D(1),D(2),kind=8))>tol) then
      call u_test_failed(__LINE__)


### PR DESCRIPTION
This is a very small pull request.